### PR TITLE
bugfixes

### DIFF
--- a/MacLinux/README.txt
+++ b/MacLinux/README.txt
@@ -36,6 +36,11 @@ Rules
      IAM Role        - config_lambda_basic_execution
 - The lambda function $RULE_NAME.zip needs to be in the same directory as the createRule script
 
+
+Example:
+./createRule default python s3_ver ./pythonlambdas/S3-VersioningEnabled.py "AWS::S3::Bucket"
+
+
 At this point, you have written and created a rule that maybe works, which you need to test. 
 Remember that rules evaluate against certain resources, so you need to create those
 resources in your account. For example, if you are writing an EC2 rule, create an ec2

--- a/MacLinux/rules/createRule
+++ b/MacLinux/rules/createRule
@@ -1,16 +1,24 @@
 #!/bin/bash 
 # ZipFile name = $RULE_NAME.zip
-if [ $# -ne 4 ]
+if [ $# -ne 5 ]
     then
-        printf $'Usage: ./createRule PROFILE RUNTIME RULE_NAME APPLICABLE_RESOURCE_TYPES\n'
-		printf $'Example: ./createRule myCLIprofile nodejs desiredInstanceTypeRule "AWS::EC2::Instance,AWS::EC2::VPC"\n'
+        printf $'Usage: ./createRule PROFILE RUNTIME RULE_NAME CODE_FILE APPLICABLE_RESOURCE_TYPES\n'
+		printf $'Example: ./createRule myCLIprofile nodejs desiredInstanceTypeRule codefile "AWS::EC2::Instance,AWS::EC2::VPC"\n'
         printf $'Use "default" for PROFILE if you want to use the default profile'
+        echo
         exit 1
 fi
 PROFILE=$1
 RUNTIME=$2
 RULE_NAME=$3
-RESOURCE_TYPES=$4
+CODE_FILE=$4
+echo "CODEFILE" $CODE_FILE
+
+MODULE_NAME=$(basename "$CODE_FILE")
+MODULE_NAME="${MODULE_NAME%.*}"
+echo "MODULE is " $MODULE_NAME
+
+RESOURCE_TYPES=$5
 if [ "$RUNTIME" = 'nodejs' ]
     then
         LAMBDA_RUNTIME='nodejs6.10'
@@ -24,7 +32,7 @@ fi
 RESOURCE_TYPES=${RESOURCE_TYPES//\"/}
 RESOURCE_TYPES=${RESOURCE_TYPES//,/\",\"}
 RESOURCE_TYPES="[\"$RESOURCE_TYPES\"]"
-zip -j $RULE_NAME.zip ruleCode/$RUNTIME/* > /dev/null
+zip -j $RULE_NAME.zip $CODE_FILE > /dev/null
 if aws --profile $PROFILE iam get-role --role-name config_lambda_basic_execution 2>&1 | grep -q 'Role not found'
     then
         printf "Creating IAM role config_lambda_basic_execution\n"
@@ -41,7 +49,7 @@ if aws --profile $PROFILE iam get-role --role-name config_lambda_basic_execution
 fi
 LAMBDA_ROLE_ARN=$(aws --profile $PROFILE iam get-role --role-name config_lambda_basic_execution --query Role.Arn --output text)
 printf "Creating/Updating Lambda function $RULE_NAME\n"
-aws --profile $PROFILE lambda create-function --function-name $RULE_NAME --zip-file fileb://$RULE_NAME.zip --runtime $LAMBDA_RUNTIME --role $LAMBDA_ROLE_ARN --handler rule_code.lambda_handler > /dev/null
+aws --profile $PROFILE lambda create-function --function-name $RULE_NAME --zip-file fileb://$RULE_NAME.zip --runtime $LAMBDA_RUNTIME --role $LAMBDA_ROLE_ARN --handler $MODULE_NAME.lambda_handler > /dev/null
 aws --profile $PROFILE lambda update-function-code --function-name $RULE_NAME --zip-file fileb://$RULE_NAME.zip > /dev/null
 aws --profile $PROFILE lambda add-permission --function-name $RULE_NAME --statement-id 1 --principal config.amazonaws.com --action lambda:InvokeFunction > /dev/null 2>&1
 LAMBDA_ARN=$(aws --profile $PROFILE lambda get-function --function-name $RULE_NAME --query Configuration.FunctionArn --output text)

--- a/MacLinux/rules/createRule
+++ b/MacLinux/rules/createRule
@@ -32,7 +32,7 @@ fi
 RESOURCE_TYPES=${RESOURCE_TYPES//\"/}
 RESOURCE_TYPES=${RESOURCE_TYPES//,/\",\"}
 RESOURCE_TYPES="[\"$RESOURCE_TYPES\"]"
-zip -j $RULE_NAME.zip $CODE_FILE > /dev/null
+zip -j $RULE_NAME.zip $CODE_FILE ruleCode/python/rule_util.py > /dev/null
 if aws --profile $PROFILE iam get-role --role-name config_lambda_basic_execution 2>&1 | grep -q 'Role not found'
     then
         printf "Creating IAM role config_lambda_basic_execution\n"

--- a/MacLinux/rules/evaluateRuleAndGetLogs
+++ b/MacLinux/rules/evaluateRuleAndGetLogs
@@ -8,7 +8,7 @@ if [ $# -ne 2 ]
 fi
 PROFILE=$1
 RULE_NAME=$2
-ECHO Evaluating rule $RULE_NAME
+echo Evaluating rule $RULE_NAME
 aws --profile $PROFILE configservice start-config-rules-evaluation --config-rule-name $RULE_NAME
 SLEEP_CYCLES=0
 while [ $SLEEP_CYCLES -ne 4 ]
@@ -19,5 +19,5 @@ do
 done
 LOG_STREAM_NAME_OUTPUT=$(aws --profile $PROFILE logs describe-log-streams --log-group-name /aws/lambda/$RULE_NAME --order-by LastEventTime --descending --max-items 1 --query 'logStreams[*].[logStreamName]' --output text)
 LOG_STREAM_NAME=(${LOG_STREAM_NAME_OUTPUT/// })
-ECHO $LOG_STREAM_NAME
+echo $LOG_STREAM_NAME
 aws --profile $PROFILE logs get-log-events --log-group-name /aws/lambda/$RULE_NAME --log-stream-name $LOG_STREAM_NAME

--- a/MacLinux/test/test
+++ b/MacLinux/test/test
@@ -9,7 +9,7 @@ fi
 PROFILE=$1
 RULE_NAME=$2
 EVENT=$(<"testUtil/testEvent.json")
-PARAMETERS=$(<"ruleCode/ruleParameters.txt")
+PARAMETERS=$(<"../rules/ruleCode/ruleParameters.txt")
 PARAMETERS=${PARAMETERS//\"/\\\"}
 EVENT=${EVENT//<PARAMETERS>/$PARAMETERS}
 for ci in testUtil/noncompliantCIs/*


### PR DESCRIPTION
Fix for:
1. In MacLinux/test ./test does not work out of the box because it references a directory under rules. 
2. evaluateRuleAndGetLogs has upper case "echo" commands this fails on bash/linux