### PR TITLE
rdk init fails if default region is us-east-1

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -114,7 +114,7 @@ class rdk():
 
             if not bucket_exists:
                 print('Creating Config bucket '+config_bucket_name )
-                if my_session.region_name == "us-east-1":
+                if my_session.region_name == 'us-east-1':
                      my_s3.create_bucket(
                              Bucket=config_bucket_name
                      )

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -114,12 +114,17 @@ class rdk():
 
             if not bucket_exists:
                 print('Creating Config bucket '+config_bucket_name )
-                my_s3.create_bucket(
-                    Bucket=config_bucket_name,
-                    CreateBucketConfiguration={
-                        'LocationConstraint': my_session.region_name
-                    }
-                )
+                if my_session.region_name == "us-east-1":
+                     my_s3.create_bucket(
+                             Bucket=config_bucket_name
+                     )
+                else:
+                     my_s3.create_bucket(
+                         Bucket=config_bucket_name,
+                         CreateBucketConfiguration={
+                             'LocationConstraint': my_session.region_name
+                         }
+                     )
 
         if not config_role_arn:
             #create config role


### PR DESCRIPTION
failing to create config-bucket in us-east-1 region because of LocationConstraints in create_bucket call.
