### PR TITLE
Rulesets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,38 @@ Once the Rule has been deployed to AWS you can get the CloudWatch logs associate
 
 You can use the ``-n`` and ``-f`` command line flags just like the UNIX ``tail`` command to view a larger number of log events and to continuously poll for new events.  The latter option can be useful in conjunction with manually initiating Config Evaluations for your deploy Config Rule to make sure it is behaving as expected.
 
+RuleSets
+--------
+New as of version 0.3.11, it is possible to add RuleSet tags to rules that can be used to deploy and test groups of rules together.  Rules can belong to multiple RuleSets, and RuleSet membership is stored only in the parameters.json metadata.  The `deploy` and `test-local` commands are RuleSet-aware such that a RuleSet can be passed in as the target instead of `--all` or a specific named Rule.
+
+A comma-delimited list of RuleSets can be added to a Rule when you create it (using the `--rulesets` flag), as part of a `modify` command, or using new `ruleset` subcommands to add or remove individual rules from a RuleSet.
+
+Running `rdk rulesets list` will display a list of the RuleSets currently defined across all of the Rules in the working directory
+
+::
+
+  rdk-dev $ rdk rulesets list
+  RuleSets:  AnotherRuleSet MyNewSet
+
+Naming a specific RuleSet will list all of the Rules that are part of that RuleSet.
+
+::
+
+  rdk-dev $ rdk rulesets list AnotherRuleSet
+  Rules in AnotherRuleSet :  RSTest
+
+Rules can be added to or removed from RuleSets using the `add` and `remove` subcommands:
+
+::
+
+  rdk-dev $ rdk rulesets add MyNewSet RSTest
+  RSTest added to RuleSet MyNewSet
+
+  rdk-dev $ rdk rulesets remove AnotherRuleSet RSTest
+  RSTest removed from RuleSet AnotherRuleSet
+
+Future enhancements related to packaging and publishing rules suitable for larger enterprise environments will use this functionality more extensively.  For now it is a convenient way to maintain a single repository of Config Rules that may need to have subsets of them deployed to different environments.  For example your development environment may contain some of the Rules that you run in Production but not all of them; RuleSets gives you a way to identify and selectively deploy the appropriate Rules to each environment.
+
 Running the tests
 =================
 

--- a/bin/rdk
+++ b/bin/rdk
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     parser.add_argument('-r','--region',help='Select the region to run against.')
     #parser.add_argument('--verbose','-v', action='count')
     #Removed for now from command choices: 'test-remote', 'status'
-    parser.add_argument('command', metavar='<command>', help='Command to run.  Choose one of init, create, modify, deploy, sample-ci, logs.', choices=['init', 'create', 'modify', 'deploy', 'test-local', 'sample-ci', 'logs'])
+    parser.add_argument('command', metavar='<command>', help='Command to run.  Choose one of init, create, modify, deploy, sample-ci, logs, rulesets.', choices=['init', 'create', 'modify', 'deploy', 'test-local', 'sample-ci', 'logs', 'rulesets'])
     parser.add_argument('command_args', metavar='<command arguments>', nargs=argparse.REMAINDER, help="Run `rdk <command> --help` to see command-specific arguments.")
 
     args = parser.parse_args()

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -878,10 +878,10 @@ class rdk():
         return my_json['Parameters']
 
     def __parse_rule_args(self, is_required):
-        usage_string = "[--runtime <runtime>] [--resource-types <resource types>] [--maximum-frequency <max execution frequency>] [--input-parameters <parameter JSON>]"
+        usage_string = "[--runtime <runtime>] [--resource-types <resource types>] [--maximum-frequency <max execution frequency>] [--input-parameters <parameter JSON>] [--rulesets <RuleSet tags>]"
 
         if is_required:
-            usage_string = "--runtime <runtime> [ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags]"
+            usage_string = "--runtime <runtime> [ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags] [--rulesets <RuleSet tags>]"
 
         parser = argparse.ArgumentParser(
             prog='rdk '+self.args.command,

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -217,9 +217,9 @@ class rdk():
         if self.args.runtime not in extension_mapping:
             print ("rdk does nto support that runtime yet.")
 
-        if not self.args.maximum_frequency:
-            self.args.maximum_frequency = "TwentyFour_Hours"
-            print("Defaulting to TwentyFour_Hours Maximum Frequency.")
+        #if not self.args.maximum_frequency:
+        #    self.args.maximum_frequency = "TwentyFour_Hours"
+        #    print("Defaulting to TwentyFour_Hours Maximum Frequency.")
 
         #create rule directory.
         rule_path = os.path.join(os.getcwd(), rules_dir, self.args.rulename)

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -302,8 +302,9 @@ class rdk():
         if not self.args.input_parameters and old_params['Parameters']['InputParameters']:
             self.args.input_parameters = old_params['Parameters']['InputParameters']
 
-        if not self.args.rulesets and old_params['Parameters']['RuleSets']:
-            self.args.rulesets = old_params['Parameters']['RuleSets']
+        if 'RuleSets' in old_params['Parameters']:
+            if not self.args.rulesets:
+                self.args.rulesets = old_params['Parameters']['RuleSets']
 
         #Write the parameters to a file in the rule directory.
         self.__populate_params()
@@ -679,7 +680,7 @@ class rdk():
             print("Rule " + rulename + " is not in any RuleSets")
 
         self.__write_params_file(rulename, params['Parameters'])
-        
+
         print(rulename + " removed from RuleSet " + ruleset)
 
     def __add_ruleset_rule(self, ruleset, rulename):
@@ -712,7 +713,7 @@ class rdk():
                     rulesets.extend(my_params['Parameters']['RuleSets'])
 
                     if self.args.ruleset in my_params['Parameters']['RuleSets']:
-                        print("Found rule! " + obj_name)
+                        #print("Found rule! " + obj_name)
                         rules.append(obj_name)
 
         if self.args.ruleset:
@@ -952,7 +953,7 @@ class rdk():
         if self.args.rulesets:
             parameters['RuleSets'] = self.args.rulesets
 
-        __write_params_file(self.args.rulename, parameters)
+        self.__write_params_file(self.args.rulename, parameters)
 
     def __write_params_file(self, rulename, parameters):
         my_params = {"Parameters": parameters}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readme():
         return f.read()
 
 setup(name='rdk',
-      version='0.3.10',
+      version='0.3.11',
       description='Rule Development Kit CLI for AWS Config',
       long_description=readme(),
       url='https://github.com/awslabs/aws-config-rdk/',


### PR DESCRIPTION
A new feature that allows for tagging Rules into "Rule Sets" that can be deployed or tested as a subset of the Rules in the working directory.  This is intended to make life easier for teams managing large numbers of Rules with the RDK directly, and will also support publishing/packaging features aimed at large enterprises that are coming down the pipe.

This PR also includes a minor bugfix for the `modify` command.