### PR TITLE
Add ReadOnly to Config Role

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -157,6 +157,7 @@ class rdk():
 
             #attach role policy
             my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:aws:iam::aws:policy/service-role/AWSConfigRole')
+            my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:aws:iam::aws:policy/ReadOnlyAccess')
             policy_template = open(os.path.join(path.dirname(__file__), 'template', delivery_permission_policy_file), 'r').read()
             delivery_permissions_policy = policy_template.replace('ACCOUNTID', account_id)
             my_iam.put_role_policy(RoleName=config_role_name, PolicyName='ConfigDeliveryPermissions', PolicyDocument=delivery_permissions_policy)


### PR DESCRIPTION
Simplify permission management when cross account is enabled.