### PR TITLE
Error handling when CFN template fails and few other enhancements

### DIFF
--- a/bin/rdk
+++ b/bin/rdk
@@ -9,7 +9,7 @@
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import argparse
-from rdk import rdk
+from rdk import rdk, __version__
 
 if __name__ == "__main__":
     #Set up command-line argument parser.
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     #Removed for now from command choices: 'test-remote', 'status'
     parser.add_argument('command', metavar='<command>', help='Command to run.  Choose one of init, create, modify, deploy, sample-ci, logs, rulesets.', choices=['init', 'create', 'modify', 'deploy', 'test-local', 'sample-ci', 'logs', 'rulesets', 'create-rule-template'])
     parser.add_argument('command_args', metavar='<command arguments>', nargs=argparse.REMAINDER, help="Run `rdk <command> --help` to see command-specific arguments.")
-
+    parser.add_argument('-v','--version', help='Display the version of this tool', action="version", version=__version__)
     args = parser.parse_args()
 
     my_rdk = rdk.rdk(args)

--- a/bin/rdk
+++ b/bin/rdk
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     #Removed for now from command choices: 'test-remote', 'status'
     parser.add_argument('command', metavar='<command>', help='Command to run.  Choose one of init, create, modify, deploy, sample-ci, logs, rulesets.', choices=['init', 'create', 'modify', 'deploy', 'test-local', 'sample-ci', 'logs', 'rulesets', 'create-rule-template'])
     parser.add_argument('command_args', metavar='<command arguments>', nargs=argparse.REMAINDER, help="Run `rdk <command> --help` to see command-specific arguments.")
-    parser.add_argument('-v','--version', help='Display the version of this tool', action="version", version=__version__)
+    parser.add_argument('-v','--version', help='Display the version of this tool', action="version", version='%(prog)s '+__version__)
     args = parser.parse_args()
 
     my_rdk = rdk.rdk(args)

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -5,3 +5,6 @@
 #        http://aws.amazon.com/apache2.0/
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+
+__version__ = "0.3.20"

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1057,7 +1057,8 @@ class rdk():
 
         if self.args.ruleset:
             rules.sort()
-            print("Rules in", self.args.ruleset, ": ", *rules)
+            print("Rules in", self.args.ruleset, ": ")
+            print(*rules, sep="\n")
         else:
             deduped = list(set(rulesets))
             deduped.sort()


### PR DESCRIPTION
issue #10 
now it detects when the CFN template fails and displays failure events
Tested with below scenarios:
++ when the rule already exists with the same name as the newly created rule.
++ when the lambda function exists with the same name.

issue #75 
Displays rules in a newline

issue #76 
Displays rdk version when `-v` or `--version` is specified
