### PR TITLE
batchfile wrapper for rdk

### DIFF
--- a/bin/rdk.cmd
+++ b/bin/rdk.cmd
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+set PythonExe=
+set PythonExeFlags=
+
+REM "loop to find the full path for python executable file"
+for %%i in (cmd bat exe) do (
+    for %%j in (python.%%i) do (
+        call :SetPythonExe "%%~$PATH:j"
+    )
+)
+
+REM "sets the python path using ftype command"
+for /f "tokens=2 delims==" %%i in ('assoc .py') do (
+    for /f "tokens=2 delims==" %%j in ('ftype %%i') do (
+        for /f "tokens=1" %%k in ("%%j") do (
+            call :SetPythonExe %%k
+        )
+    )
+)
+REM "Run rdk file using python"
+"%PythonExe%" %PythonExeFlags% "%~dpn0" %*
+goto :EOF
+
+REM "Subroutine for setting python executables path to PythonExe variable"
+:SetPythonExe
+if not [%1]==[""] (
+    if ["%PythonExe%"]==[""] (
+        set PythonExe=%~1
+    )
+)
+goto :EOF

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(name='rdk',
           'mock',
           'future',
       ],
-      scripts=['bin/rdk'],
+      scripts=['bin/rdk','bin/rdk.cmd'],
       zip_safe=False,
       include_package_data=True)


### PR DESCRIPTION
[windows] issue #80 

this wrapper allows to run rdk in any directory without using the full path of rdk file.
++ typing `rdk` command in any directory should execute rdk
