### PR TITLE
New feature to deploy AWS Managed Rules with RDK

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,13 @@ Rules can be added to or removed from RuleSets using the `add` and `remove` subc
 
 RuleSets are a convenient way to maintain a single repository of Config Rules that may need to have subsets of them deployed to different environments.  For example your development environment may contain some of the Rules that you run in Production but not all of them; RuleSets gives you a way to identify and selectively deploy the appropriate Rules to each environment.
 
+Managed Rules
+-------------
+The RDK is able to deploy AWS Managed Rules. 
+
+To do so, create a rule using "rdk create". Delete all the files, except "parameters.json". In the parameters.json, add - in the "Parameters" array - the key "SourceIdentifier" with the value found in the AWS Config documentation (e.g. "GUARDDUTY_ENABLED_CENTRALIZED").
+
+You can use "rdk deploy" or "rdk create-rule-template". 
 
 Contributing
 ============
@@ -252,3 +259,9 @@ Acknowledgments
 ===============
 
 * the boto3 team makes all of this magic possible.
+
+
+Link
+====
+
+* to view example of rules built with the RDK: https://github.com/awslabs/aws-config-rules/tree/master/python

--- a/README.rst
+++ b/README.rst
@@ -231,9 +231,7 @@ Managed Rules
 -------------
 The RDK is able to deploy AWS Managed Rules. 
 
-To do so, create a rule using "rdk create". Delete all the files, except "parameters.json". In the parameters.json, add - in the "Parameters" array - the key "SourceIdentifier" with the value found in the AWS Config documentation (e.g. "GUARDDUTY_ENABLED_CENTRALIZED").
-
-You can use "rdk deploy" or "rdk create-rule-template". 
+To do so, create a rule using "rdk create" and provide a valid SourceIdentifier via the --source-identifier CLI option. The list of Managed Rules can be found here: https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html, and note that the Identifier can be obtained by replacing the dashes with underscores and using all capitals (for example, the "guardduty-enabled-centralized" rule has the SourceIdentifier "GUARDDUTY_ENABLED_CENTRALIZED").  Just like custom Rules you will need to specify source events and/or a maximum evaluation frequency, and also pass in any Rule parameters.  The resulting Rule directory will contain only the parameters.json file, but using `rdk deploy` or `rdk create-rule-template` can be used to deploy the Managed Rule like any other Custom Rule.
 
 Contributing
 ============

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1,4 +1,4 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#    Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
 #
@@ -27,6 +27,13 @@ import subprocess
 from subprocess import call
 import fnmatch
 import unittest
+
+#sphinx-argparse is a delight.
+try:
+    from rdk import MY_VERSION
+except ImportError:
+    MY_VERSION = "<version>"
+    pass
 
 try:
     from unittest.mock import MagicMock, patch, ANY
@@ -59,9 +66,160 @@ accepted_resource_types = ['AWS::CloudFront::Distribution', 'AWS::CloudFront::St
                         'AWS::WAF::RateBasedRule', 'AWS::WAF::Rule', 'AWS::WAF::WebACL', 'AWS::WAF::RuleGroup', 'AWS::WAFRegional::RateBasedRule', 'AWS::WAFRegional::Rule', 'AWS::WAFRegional::WebACL', 'AWS::WAFRegional::RuleGroup', 'AWS::XRay::EncryptionConfig', 'AWS::ElasticLoadBalancingV2::LoadBalancer', 'AWS::ElasticLoadBalancing::LoadBalancer',
                         'AWS::ElasticLoadBalancingV2::LoadBalancer']
 
-class rdk():
+def get_command_parser():
+    #This is needed to get sphinx to auto-generate the CLI documentation correctly.
+    if '__version__' not in globals() and '__version__' not in locals():
+        __version__ = "<version>"
+
+    parser = argparse.ArgumentParser(
+        #formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='The RDK is a command-line utility for authoring, deploying, and testing custom AWS Config rules.'
+        )
+    parser.add_argument('-p','--profile', help="[optional] indicate which Profile to use.")
+    parser.add_argument('-k','--access-key-id', help="[optional] Access Key ID to use.")
+    parser.add_argument('-s','--secret-access-key', help="[optional] Secret Access Key to use.")
+    parser.add_argument('-r','--region',help='Select the region to run the command in.')
+    #parser.add_argument('--verbose','-v', action='count')
+    #Removed for now from command choices: 'test-remote', 'status'
+    parser.add_argument('command', metavar='<command>', help='Command to run.  Refer to the usage instructions for each command for more details', choices=['clean', 'create', 'create-rule-template', 'deploy', 'init', 'logs', 'modify', 'rulesets', 'sample-ci', 'test-local', 'undeploy'])
+    parser.add_argument('command_args', metavar='<command arguments>', nargs=argparse.REMAINDER, help="Run `rdk <command> --help` to see command-specific arguments.")
+    parser.add_argument('-v','--version', help='Display the version of this tool', action="version", version='%(prog)s '+MY_VERSION)
+
+    return parser
+
+def get_init_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk init',
+        description = 'Sets up AWS Config.  This will enable configuration recording in AWS and ensure necessary S3 buckets and IAM Roles are created.')
+
+    return parser
+
+def get_clean_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk clean',
+        description = 'Removes AWS Config from the account.  This will disable all Config rules and no configuration changes will be recorded!')
+    parser.add_argument("--force", required=False, action='store_true', help='[optional] Clean account without prompting for confirmation.')
+
+    return parser
+
+def get_create_parser():
+    return get_rule_parser(True, "create")
+
+def get_modify_parser():
+    return get_rule_parser(False, "modify")
+
+def get_rule_parser(is_required, command):
+    usage_string = "[--runtime <runtime>] [--resource-types <resource types>] [--maximum-frequency <max execution frequency>] [--input-parameters <parameter JSON>] [--tags <tags JSON>] [--rulesets <RuleSet tags>]"
+
+    if is_required:
+        usage_string = "--runtime <runtime> [ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags] [--rulesets <RuleSet tags>]"
+
+    parser = argparse.ArgumentParser(
+        prog='rdk '+command,
+        usage="rdk "+command + " <rulename> " + usage_string,
+        description="Rules are stored in their own directory along with their metadata.  This command is used to " + command + " the Rule and metadata."
+    )
+    parser.add_argument('rulename', metavar='<rulename>', help='Rule name to create/modify')
+    runtime_group = parser.add_mutually_exclusive_group(required=is_required)
+    runtime_group.add_argument('-R','--runtime', required=False, help='Runtime for lambda function', choices=['nodejs4.3','java8','python2.7','python3.6','dotnetcore1.0','dotnetcore2.0'])
+    runtime_group.add_argument('--source-identifier', required=False, help="[optional] Used only for creating Managed Rules.")
+    parser.add_argument('-r','--resource-types', required=False, help='[optional] Resource types that will trigger event-based Rule evaluation')
+    parser.add_argument('-m','--maximum-frequency', required=False, help='[optional] Maximum execution frequency for scheduled Rules', choices=['One_Hour','Three_Hours','Six_Hours','Twelve_Hours','TwentyFour_Hours'])
+    parser.add_argument('-i','--input-parameters', help="[optional] JSON for required Config parameters.")
+    parser.add_argument('--optional-parameters', help="[optional] JSON for optional Config parameters.")
+    parser.add_argument('--tags', help="[optional] JSON for tags to be applied to all CFN created resources.")
+    parser.add_argument('-s','--rulesets', required=False, help='[optional] comma-delimited list of RuleSet names to add this Rule to')
+    return parser
+
+def get_undeploy_parser():
+    return get_deployment_parser(ForceArgument=True, Command="undeploy")
+
+def get_deploy_parser():
+    return get_deployment_parser()
+
+def get_deployment_parser(ForceArgument=False, Command="deploy"):
+    direction = "to"
+    if Command=="undeploy":
+        direction = "from"
+
+    parser = argparse.ArgumentParser(
+        prog='rdk '+Command,
+        description="Used to " + Command + " the Config Rule " + direction + " the target account."
+    )
+    parser.add_argument('rulename', metavar='<rulename>', nargs='*', help='Rule name(s) to deploy.  Rule(s) will be pushed to AWS.')
+    parser.add_argument('--all','-a', action='store_true', help="All rules in the working directory will be deployed.")
+    parser.add_argument('-s','--rulesets', required=False, help='comma-delimited list of RuleSet names')
+    parser.add_argument('-f','--functions-only', action='store_true', required=False, help="[optional] Only deploy Lambda functions.  Useful for cross-account deployments.")
+    parser.add_argument('--stack-name', required=False, help="[optional] CloudFormation Stack name for use with --functions-only option.  If omitted, \"RDK-Config-Rule-Functions\" will be used." )
+    if ForceArgument:
+        parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
+    return parser
+
+def get_test_parser(command):
+    parser = argparse.ArgumentParser(
+        prog='rdk '+command,
+        description="Used to run tests on your Config Rule code."
+    )
+    parser.add_argument('rulename', metavar='<rulename>[,<rulename>,...]', nargs='*', help='Rule name(s) to test')
+    parser.add_argument('--all','-a', action='store_true', help="Test will be run against all rules in the working directory.")
+    parser.add_argument('--test-ci-json', '-j', help="[optional] JSON for test CI for testing.")
+    parser.add_argument('--test-ci-types', '-t', help="[optional] CI type to use for testing.")
+    parser.add_argument('--verbose', '-v', action='store_true', help='[optional] Enable full log output')
+    parser.add_argument('-s','--rulesets', required=False, help='[p[tional] comma-delimited list of RuleSet names')
+    return parser
+
+def get_test_local_parser():
+    return get_test_parser("test-local")
+
+def get_sample_ci_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk sample-ci',
+        description="Provides a way to see sample configuration items for most supported resource types."
+    )
+    parser.add_argument('ci_type', metavar='<resource type>', help='Resource name (e.g. "AWS::EC2::Instance") to display a sample CI JSON document for.', choices=accepted_resource_types)
+    return parser
+
+def get_logs_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk logs',
+        usage="rdk logs <rulename> [-n/--number NUMBER] [-f/--follow]",
+        description="Displays CloudWatch logs for the Lambda Function for the specified Rule."
+    )
+    parser.add_argument('rulename', metavar='<rulename>', help='Rule whose logs will be displayed')
+    parser.add_argument('-f','--follow',  action='store_true', help='[optional] Continuously poll Lambda logs and write to stdout.')
+    parser.add_argument('-n','--number',  default=3, help='[optional] Number of previous logged events to display.')
+    return parser
+
+def get_rulesets_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk rulesets',
+        usage="rdk rulesets [list | [ [ add | remove ] <ruleset> <rulename> ]",
+        description="Used to describe and manipulate RuleSet tags on Rules."
+    )
+    parser.add_argument('subcommand', help="One of list, add, or remove")
+    parser.add_argument('ruleset', nargs='?', help="Name of RuleSet")
+    parser.add_argument('rulename', nargs='?', help="Name of Rule to be added or removed")
+    return parser
+
+def get_create_rule_template_parser():
+    parser = argparse.ArgumentParser(
+        prog='rdk create-rule-template',
+        description="Outputs a CloudFormation template that can be used to deploy Config Rules in other AWS Accounts."
+    )
+    parser.add_argument('rulename', metavar='<rulename>', nargs='*', help='Rule name(s) to include in template.  A CloudFormation template will be created, but Rule(s) will not be pushed to AWS.')
+    parser.add_argument('--all','-a', action='store_true', help="All rules in the working directory will be included in the generated CloudFormation template.")
+    parser.add_argument('-s','--rulesets', required=False, help='comma-delimited RuleSet names to be included in the generated template.')
+    parser.add_argument('-o','--output-file', required=True, default="RDK-Config-Rules", help="filename of generated CloudFormation template")
+    parser.add_argument('--rules-only', action="store_true", help="[optional] Generate a CloudFormation Template that only includes the Config Rules and not the Bucket, Configuration Recorder, and Delivery Channel.")
+    return parser
+
+class rdk:
     def __init__(self, args):
         self.args = args
+
+    @staticmethod
+    def get_command_parser(self):
+        return get_commmand_parser()
 
     def process_command(self):
         method_to_call = getattr(self, self.args.command.replace('-','_'))
@@ -70,21 +228,11 @@ class rdk():
         return(exit_code)
 
     def init(self):
-        parser = argparse.ArgumentParser(
-            prog='rdk '+self.args.command,
-            description = 'Sets up AWS Config and turn current directory into a rdk working directory.  This will enable configuration recording in AWS.')
-        self.args = parser.parse_args(self.args.command_args, self.args)
-
+        """
+            This is a test.
+        """
+        self.args = get_init_parser().parse_args(self.args.command_args, self.args)
         print ("Running init!")
-
-        #if the .rdk directory exists, delete it.
-        #if  os.path.exists(rdk_dir):
-        #    shutil.rmtree(rdk_dir)
-
-        #copy contents of template directory into .rdk directory
-        #src = os.path.join(path.dirname(__file__), 'template')
-        #dst = rdk_dir
-        #shutil.copytree(src, dst)
 
         #create custom session based on whatever credentials are available to us
         my_session = self.__get_boto_session()
@@ -92,10 +240,10 @@ class rdk():
         #Create our ConfigService client
         my_config = my_session.client('config')
 
-        #get accountID
-        my_sts = my_session.client('sts')
-        response = my_sts.get_caller_identity()
-        account_id = response['Account']
+        #get accountID, AWS partition (e.g. aws or aws-us-gov), region (us-east-1, us-gov-west-1)
+        identity_details = self.__get_caller_identity_details(my_session)
+        account_id = identity_details['account_id']
+        partition = identity_details['partition']
 
         config_recorder_exists = False
         config_recorder_name = "default"
@@ -166,8 +314,8 @@ class rdk():
                 my_iam.create_role(RoleName=config_role_name, AssumeRolePolicyDocument=json.dumps(assume_role_policy), Path="/rdk/")
 
             #attach role policy
-            my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:aws:iam::aws:policy/service-role/AWSConfigRole')
-            my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:aws:iam::aws:policy/ReadOnlyAccess')
+            my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:' + partition + ':iam::aws:policy/service-role/AWSConfigRole')
+            my_iam.attach_role_policy(RoleName=config_role_name, PolicyArn='arn:' + partition + ':iam::aws:policy/ReadOnlyAccess')
             policy_template = open(os.path.join(path.dirname(__file__), 'template', delivery_permission_policy_file), 'r').read()
             delivery_permissions_policy = policy_template.replace('ACCOUNTID', account_id)
             my_iam.put_role_policy(RoleName=config_role_name, PolicyName='ConfigDeliveryPermissions', PolicyDocument=delivery_permissions_policy)
@@ -178,7 +326,7 @@ class rdk():
 
         #create or update config recorder
         if not config_role_arn:
-            config_role_arn = "arn:aws:iam::"+account_id+":role/rdk/config-role"
+            config_role_arn = "arn:" + partition + ":iam::" + account_id + ":role/rdk/config-role"
 
         my_config.put_configuration_recorder(ConfigurationRecorder={'name':config_recorder_name, 'roleARN':config_role_arn, 'recordingGroup':{'allSupported':True, 'includeGlobalResourceTypes': True}})
 
@@ -222,12 +370,7 @@ class rdk():
 
         return 0
     def clean(self):
-        parser = argparse.ArgumentParser(
-            prog='rdk '+self.args.command,
-            description = 'Removes AWS Config from the account.  This is a big deal!')
-        parser.add_argument("--force", required=False, action='store_true', help='Clean account with prompting for confirmation.')
-        self.args = parser.parse_args(self.args.command_args, self.args)
-
+        self.args = get_clean_parser().parse_args(self.args.command_args, self.args)
 
         if not self.args.force:
             confirmation = False
@@ -254,9 +397,8 @@ class rdk():
         cfn_client = my_session.client('cloudformation')
 
         #get accountID
-        my_sts = my_session.client('sts')
-        response = my_sts.get_caller_identity()
-        account_id = response['Account']
+        identity_details = self.__get_caller_identity_details(my_session)
+        account_id = identity_details['account_id']
 
         config_recorder_name = ""
         config_role_arn = ""
@@ -327,7 +469,7 @@ class rdk():
         self.args.all = True
         rule_names = self.__get_rule_list_for_command()
         for rule_name in rule_names:
-            my_stack_name = self.__get_alphanumeric_rule_name(rule_name)
+            my_stack_name = self.__get_stack_name_from_rule_name(rule_name)
             try:
                 cfn_client.delete_stack(StackName=my_stack_name)
             except Exception as e:
@@ -448,8 +590,14 @@ class rdk():
         if not self.args.input_parameters and 'InputParameters' in old_params['Parameters']:
             self.args.input_parameters = old_params['Parameters']['InputParameters']
 
+        if not self.args.optional_parameters and 'OptionalParameters' in old_params['Parameters']:
+            self.args.optional_parameters = old_params['Parameters']['OptionalParameters']
+
         if not self.args.source_identifier and 'SourceIdentifier' in old_params['Parameters']:
             self.args.source_identifier = old_params['Parameters']['SourceIdentifier']
+
+        if not self.args.tags and old_params['Tags']:
+            self.args.tags = old_params['Tags']
 
         if 'RuleSets' in old_params['Parameters']:
             if not self.args.rulesets:
@@ -498,8 +646,8 @@ class rdk():
 
         for rule_name in rule_names:
             try:
-                cfn_client.delete_stack(StackName=self.__get_alphanumeric_rule_name(rule_name))
-                deleted_stacks.append(self.__get_alphanumeric_rule_name(rule_name))
+                cfn_client.delete_stack(StackName=self.__get_stack_name_from_rule_name(rule_name))
+                deleted_stacks.append(self.__get_stack_name_from_rule_name(rule_name))
             except ClientError as ce:
                 print("Client Error encountered attempting to delete CloudFormation stack for Rule: " + str(ce))
             except Exception as e:
@@ -526,9 +674,9 @@ class rdk():
         my_session = self.__get_boto_session()
 
         #get accountID
-        my_sts = my_session.client('sts')
-        response = my_sts.get_caller_identity()
-        account_id = response['Account']
+        identity_details = self.__get_caller_identity_details(my_session)
+        account_id = identity_details['account_id']
+        partition = identity_details['partition']
 
         code_bucket_name = code_bucket_prefix + account_id + "-" + my_session.region_name
 
@@ -548,7 +696,7 @@ class rdk():
             #Write template to S3
             my_s3_client = my_session.client('s3')
             my_s3_client.put_object(
-                Body=bytes(function_template, 'utf-8'),
+                Body=bytes(function_template.encode('utf-8')),
                 Bucket=code_bucket_name,
                 Key=self.args.stack_name + ".json"
             )
@@ -556,7 +704,7 @@ class rdk():
             #Package code and push to S3
             s3_code_objects = {}
             for rule_name in rule_names:
-                rule_params = self.__get_rule_parameters(rule_name)
+                rule_params, cfn_tags = self.__get_rule_parameters(rule_name)
                 if 'SourceIdentifier' in rule_params:
                     print("Skipping code packaging for Managed Rule.")
                 else:
@@ -575,14 +723,19 @@ class rdk():
                 #If we've gotten here, stack exists and we should update it.
                 print ("Updating CloudFormation Stack for Lambda functions.")
                 try:
-                    response = my_cfn.update_stack(
-                        StackName=self.args.stack_name,
-                        TemplateURL=my_template_url_prefix + my_session.region_name + ".amazonaws.com/"+code_bucket_name+"/" + self.args.stack_name + ".json",
-                        Parameters=cfn_params,
-                        Capabilities=[
-                            'CAPABILITY_IAM',
-                        ],
-                    )
+
+                    cfn_args = {
+                        'StackName': self.args.stack_name,
+                        'TemplateURL': my_template_url_prefix + my_session.region_name + ".amazonaws.com/" + code_bucket_name + "/" + self.args.stack_name + ".json",
+                        'Parameters': cfn_params,
+                        'Capabilities': [ 'CAPABILITY_IAM' ]
+                    }
+
+                    # If no tags key is specified, or if the tags dict is empty
+                    if cfn_tags is not None:
+                        cfn_args['Tags'] = cfn_tags
+
+                    response = my_cfn.update_stack(**cfn_args)
 
                     #wait for changes to propagate.
                     self.__wait_for_cfn_stack(my_cfn, self.args.stack_name)
@@ -600,8 +753,8 @@ class rdk():
 
                 #Push lambda code to functions.
                 for rule_name in rule_names:
-                    my_lambda_arn = self.__get_lambda_arn_for_rule(rule_name, my_session.region_name, account_id)
-                    rule_params = self.__get_rule_parameters(rule_name)
+                    my_lambda_arn = self.__get_lambda_arn_for_rule(rule_name, partition, my_session.region_name, account_id)
+                    rule_params, cfn_tags = self.__get_rule_parameters(rule_name)
                     if 'SourceIdentifier' in rule_params:
                         print("Skipping Lambda upload for Managed Rule.")
                         continue
@@ -619,14 +772,18 @@ class rdk():
                 #If we're in the exception, the stack does not exist and we should create it.
                 print ("Creating CloudFormation Stack for Lambda Functions.")
 
-                response = my_cfn.create_stack(
-                    StackName=self.args.stack_name,
-                    TemplateURL=my_template_url_prefix + my_session.region_name + ".amazonaws.com/"+code_bucket_name+"/" + self.args.stack_name + ".json",
-                    Parameters=cfn_params,
-                    Capabilities=[
-                        'CAPABILITY_IAM',
-                    ],
-                )
+                cfn_args = {
+                    'StackName': self.args.stack_name,
+                    'TemplateURL': my_template_url_prefix + my_session.region_name + ".amazonaws.com/" + code_bucket_name + "/" + self.args.stack_name + ".json",
+                    'Parameters': cfn_params,
+                    'Capabilities': ['CAPABILITY_IAM']
+                }
+
+                # If no tags key is specified, or if the tags dict is empty
+                if cfn_tags is not None:
+                    cfn_args['Tags'] = cfn_tags
+
+                response = my_cfn.create_stack(**cfn_args)
 
                 #wait for changes to propagate.
                 self.__wait_for_cfn_stack(my_cfn, self.args.stack_name)
@@ -636,19 +793,28 @@ class rdk():
 
         #If we're deploying both the functions and the Config rules, run the following process:
         for rule_name in rule_names:
-            my_rule_params = self.__get_rule_parameters(rule_name)
+            rule_params, cfn_tags = self.__get_rule_parameters(rule_name)
+            
+            #create CFN Parameters common for Managed and Custom            
+            source_events = "NONE"
+            if 'SourceEvents' in rule_params:
+                source_events = rule_params['SourceEvents']
+
+            source_periodic = "NONE"
+            if 'SourcePeriodic' in rule_params:
+                source_periodic = rule_params['SourcePeriodic']
                         
-            if 'SourceIdentifier' in my_rule_params:
+            combined_input_parameters = {}
+            if 'InputParameters' in rule_params:
+                combined_input_parameters.update(json.loads(rule_params['InputParameters']))
+
+            if 'OptionalParameters' in rule_params:
+                combined_input_parameters.update(json.loads(rule_params['OptionalParameters']))
+
+            if 'SourceIdentifier' in rule_params:
                 print("Found Managed Rule.")
-                #create CFN Parameters
-                source_events = "NONE"
-                if 'SourceEvents' in my_rule_params:
-                    source_events = my_rule_params['SourceEvents']
-
-                source_periodic = "NONE"
-                if 'SourcePeriodic' in my_rule_params:
-                    source_periodic = my_rule_params['SourcePeriodic']
-
+                #create CFN Parameters for Managed Rules
+                
                 my_params = [
                     {
                         'ParameterKey': 'RuleName',
@@ -664,11 +830,11 @@ class rdk():
                     },
                     {
                         'ParameterKey': 'SourceInputParameters',
-                        'ParameterValue': my_rule_params['InputParameters'],
+                        'ParameterValue': json.dumps(combined_input_parameters),
                     },
                     {
                         'ParameterKey': 'SourceIdentifier',
-                        'ParameterValue': my_rule_params['SourceIdentifier']
+                        'ParameterValue': rule_params['SourceIdentifier']
                     }]
 
                 #deploy config rule
@@ -676,16 +842,22 @@ class rdk():
                 my_cfn = my_session.client('cloudformation')
 
                 try:
-                    my_stack_name = self.__get_alphanumeric_rule_name(rule_name)
+                    my_stack_name = self.__get_stack_name_from_rule_name(rule_name)
                     my_stack = my_cfn.describe_stacks(StackName=my_stack_name)
                     #If we've gotten here, stack exists and we should update it.
                     print ("Updating CloudFormation Stack for " + rule_name)
                     try:
-                        response = my_cfn.update_stack(
-                            StackName=my_stack_name,
-                            TemplateBody=open(cfn_body, "r").read(),
-                            Parameters=my_params
-                        )
+                        cfn_args = {
+                            'StackName': my_stack_name,
+                            'TemplateBody': open(cfn_body, "r").read(),
+                            'Parameters': my_params
+                        }
+
+                        # If no tags key is specified, or if the tags dict is empty
+                        if cfn_tags is not None:
+                            cfn_args['Tags'] = cfn_tags
+
+                        response = my_cfn.update_stack(**cfn_args)
                     except ClientError as e:
                         if e.response['Error']['Code'] == 'ValidationError':
                             if 'No updates are to be performed.' in str(e):
@@ -697,16 +869,19 @@ class rdk():
                                 return 1
                         else:
                             raise
-
                 except ClientError as e:
                     #If we're in the exception, the stack does not exist and we should create it.
                     print ("Creating CloudFormation Stack for " + rule_name)
-                    # print(my_params)
-                    response = my_cfn.create_stack(
-                        StackName=my_stack_name,
-                        TemplateBody=open(cfn_body, "r").read(),
-                        Parameters=my_params
-                    )
+                    cfn_args = {
+                        'StackName': my_stack_name,
+                        'TemplateBody': open(cfn_body, "r").read(),
+                        'Parameters': my_params
+                    }
+
+                    if cfn_tags is not None:
+                        cfn_args['Tags'] = cfn_tags
+
+                    response = my_cfn.create_stack(**cfn_args)
 
                 #wait for changes to propagate.
                 self.__wait_for_cfn_stack(my_cfn, my_stack_name)
@@ -714,17 +889,11 @@ class rdk():
                 continue
             
             print("Found Custom Rule.")
+            
             s3_src = ""
-            s3_dst = self.__upload_function_code(rule_name, my_rule_params, account_id, my_session, code_bucket_name)
+            s3_dst = self.__upload_function_code(rule_name, rule_params, account_id, my_session, code_bucket_name)
 
-            #create CFN Parameters
-            source_events = "NONE"
-            if 'SourceEvents' in my_rule_params:
-                source_events = my_rule_params['SourceEvents']
-
-            source_periodic = "NONE"
-            if 'SourcePeriodic' in my_rule_params:
-                source_periodic = my_rule_params['SourcePeriodic']
+            #create CFN Parameters for Custom Rules
 
             my_params = [
                 {
@@ -741,7 +910,7 @@ class rdk():
                 },
                 {
                     'ParameterKey': 'SourceRuntime',
-                    'ParameterValue': my_rule_params['SourceRuntime'],
+                    'ParameterValue': rule_params['SourceRuntime'],
                 },
                 {
                     'ParameterKey': 'SourceEvents',
@@ -753,31 +922,35 @@ class rdk():
                 },
                 {
                     'ParameterKey': 'SourceInputParameters',
-                    'ParameterValue': my_rule_params['InputParameters'],
+                    'ParameterValue': json.dumps(combined_input_parameters),
                 },
                 {
                     'ParameterKey': 'SourceHandler',
-                    'ParameterValue': self.__get_handler(rule_name, my_rule_params)
+                    'ParameterValue': self.__get_handler(rule_name, rule_params)
+
                 }]
 
             #deploy config rule
             cfn_body = os.path.join(path.dirname(__file__), 'template',  "configRule.json")
             my_cfn = my_session.client('cloudformation')
-
             try:
-                my_stack_name = self.__get_alphanumeric_rule_name(rule_name)
+                my_stack_name = self.__get_stack_name_from_rule_name(rule_name)
                 my_stack = my_cfn.describe_stacks(StackName=my_stack_name)
                 #If we've gotten here, stack exists and we should update it.
                 print ("Updating CloudFormation Stack for " + rule_name)
                 try:
-                    response = my_cfn.update_stack(
-                        StackName=my_stack_name,
-                        TemplateBody=open(cfn_body, "r").read(),
-                        Parameters=my_params,
-                        Capabilities=[
-                            'CAPABILITY_IAM',
-                        ],
-                    )
+                    cfn_args = {
+                        'StackName': my_stack_name,
+                        'TemplateBody': open(cfn_body, "r").read(),
+                        'Parameters': my_params,
+                        'Capabilities': ['CAPABILITY_IAM']
+                    }
+
+                    # If no tags key is specified, or if the tags dict is empty
+                    if cfn_tags is not None:
+                        cfn_args['Tags'] = cfn_tags
+
+                    response = my_cfn.update_stack(**cfn_args)
                 except ClientError as e:
                     if e.response['Error']['Code'] == 'ValidationError':
                         if 'No updates are to be performed.' in str(e):
@@ -804,15 +977,17 @@ class rdk():
             except ClientError as e:
                 #If we're in the exception, the stack does not exist and we should create it.
                 print ("Creating CloudFormation Stack for " + rule_name)
-                # print(my_params)
-                response = my_cfn.create_stack(
-                    StackName=my_stack_name,
-                    TemplateBody=open(cfn_body, "r").read(),
-                    Parameters=my_params,
-                    Capabilities=[
-                        'CAPABILITY_IAM',
-                    ],
-                )
+                cfn_args = {
+                    'StackName': my_stack_name,
+                    'TemplateBody': open(cfn_body, "r").read(),
+                    'Parameters': my_params,
+                    'Capabilities': ['CAPABILITY_IAM']
+                }
+
+                if cfn_tags is not None:
+                    cfn_args['Tags'] = cfn_tags
+
+                response = my_cfn.create_stack(**cfn_args)
 
             #wait for changes to propagate.
             self.__wait_for_cfn_stack(my_cfn, my_stack_name)
@@ -831,7 +1006,7 @@ class rdk():
         rule_names = self.__get_rule_list_for_command()
 
         for rule_name in rule_names:
-            rule_params = self.__get_rule_parameters(rule_name)
+            rule_params, rule_tags = self.__get_rule_parameters(rule_name)
             if rule_params['SourceRuntime'] not in ('python2.7','python3.6'):
                 print ("Skipping " + rule_name + " - Runtime not supported for local testing.")
                 continue
@@ -878,8 +1053,8 @@ class rdk():
                 test_event['ruleParameters'] = json.dumps(my_parameters)
 
                 #Get the Lambda function associated with the Rule
-                my_stack_name = self.__get_alphanumeric_rule_name(rule_name)
-                my_lambda_arn = self.__get_lambda_arn_for_stack(my_stack_name)
+                my_lambda_name = self.__get_stack_name_from_rule_name(rule_name)
+                my_lambda_arn = self.__get_lambda_arn_for_stack(my_lambda_name)
 
                 #Call Lambda function with test event.
                 result = my_lambda_client.invoke(
@@ -903,21 +1078,13 @@ class rdk():
         return 0
 
     def sample_ci(self):
-        parser = argparse.ArgumentParser(prog='rdk '+self.args.command)
-        parser.add_argument('ci_type', metavar='<resource type>', help='Resource name (e.g. "AWS::EC2::Instance") to display a sample CI JSON document for.', choices=accepted_resource_types)
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_sample_ci_parser().parse_args(self.args.command_args, self.args)
 
         my_test_ci = TestCI(self.args.ci_type)
         print(json.dumps(my_test_ci.get_json(), indent=4))
 
     def logs(self):
-        parser = argparse.ArgumentParser(
-            prog='rdk ' + self.args.command,
-            usage="rdk " + self.args.command + " <rulename> [-n/--number NUMBER] [-f/--follow]")
-        parser.add_argument('rulename', metavar='<rulename>', help='Rule whose logs will be displayed')
-        parser.add_argument('-f','--follow',  action='store_true', help='Continuously poll Lambda logs and write to stdout.')
-        parser.add_argument('-n','--number',  default=3, help='Number of previous logged events to display.')
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_logs_parser().parse_args(self.args.command_args, self.args)
 
         self.args.rulename = self.__clean_rule_name(self.args.rulename)
 
@@ -978,14 +1145,7 @@ class rdk():
             print(e.response['Error']['Message'])
 
     def rulesets(self):
-        parser = argparse.ArgumentParser(
-            prog='rdk ' + self.args.command,
-            usage='rdk ' + self.args.command + " [list | [ [ add | remove ] <ruleset> <rulename> ]"
-        )
-        parser.add_argument('subcommand', help="One of list, add, or remove")
-        parser.add_argument('ruleset', nargs='?')
-        parser.add_argument('rulename', nargs='?')
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_rulesets_parser().parse_args(self.args.command_args, self.args)
 
         if self.args.subcommand in ['add','remove'] and (not self.args.ruleset or not self.args.rulename):
             print("You must specify a ruleset name and a rule for the `add` and `remove` commands.")
@@ -1001,13 +1161,7 @@ class rdk():
             print("Unknown subcommand.")
 
     def create_rule_template(self):
-        parser = argparse.ArgumentParser(prog='rdk create-rule-template')
-        parser.add_argument('rulename', metavar='<rulename>', nargs='*', help='Rule name(s) to include in template.  A CloudFormation template will be created, but Rule(s) will not be pushed to AWS.')
-        parser.add_argument('--all','-a', action='store_true', help="All rules in the working directory will be included in the generated CloudFormation template.")
-        parser.add_argument('-s','--rulesets', required=False, help='comma-delimited RuleSet names to be included in the generated template.')
-        parser.add_argument('-o','--output-file', required=True, default="RDK-Config-Rules", help="filename of generated CloudFormation template")
-        parser.add_argument('--rules-only', action="store_true", help="Generate a CloudFormation Template that only includes the Config Rules and not the Bucket, Configuration Recorder, and Delivery Channel.")
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_create_rule_template_parser().parse_args(self.args.command_args, self.args)
 
         if self.args.rulesets:
             self.args.rulesets = self.args.rulesets.split(',')
@@ -1048,8 +1202,8 @@ class rdk():
                 "RoleName": config_role_name,
                 "Path": "/rdk/",
                 "ManagedPolicyArns": [
-                    "arn:aws:iam::aws:policy/service-role/AWSConfigRole",
-                    "arn:aws:iam::aws:policy/ReadOnlyAccess"
+                    "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSConfigRole",
+                    "arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess"
                 ],
                 "AssumeRolePolicyDocument": {
                     "Version": "2012-10-17",
@@ -1068,7 +1222,7 @@ class rdk():
                             "Sid": "REMOTE",
                             "Effect": "Allow",
                             "Principal": {
-                                "AWS": {"Fn::Sub": "arn:aws:iam::${LambdaAccountId}:root"}
+                                "AWS": {"Fn::Sub": "arn:${AWS::Partition}:iam::${LambdaAccountId}:root"}
                             },
                             "Action": "sts:AssumeRole"
                         }
@@ -1083,7 +1237,7 @@ class rdk():
                                 {
                                     "Effect": "Allow",
                                     "Action": "s3:PutObject*",
-                                    "Resource": { "Fn::Sub": "arn:aws:s3:::${ConfigBucket}/AWSLogs/${AWS::AccountId}/*" },
+                                    "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${ConfigBucket}/AWSLogs/${AWS::AccountId}/*" },
                                     "Condition": {
                                         "StringLike": {
                                             "s3:x-amz-acl": "bucket-owner-full-control"
@@ -1093,7 +1247,7 @@ class rdk():
                                 {
                                     "Effect": "Allow",
                                     "Action": "s3:GetBucketAcl",
-                                    "Resource": {"Fn::Sub": "arn:aws:s3:::${ConfigBucket}"}
+                                    "Resource": {"Fn::Sub": "arn:${AWS::Partition}:s3:::${ConfigBucket}"}
                                 }
                             ]
                         }
@@ -1136,12 +1290,13 @@ class rdk():
         #Next, go through each rule in our rule list and add the CFN to deploy it.
         rule_names = self.__get_rule_list_for_command()
         for rule_name in rule_names:
-            params = self.__get_rule_parameters(rule_name)
+            params, tags = self.__get_rule_parameters(rule_name)
             input_params = json.loads(params["InputParameters"])
             for input_param in input_params:
                 cfn_param = {}
                 cfn_param["Description"] = "Pass-through to required Input Parameter " + input_param + " for Config Rule " + rule_name
-                cfn_param["Default"] = input_params[input_param]
+                if len(input_params[input_param].strip()) > 0:
+                    cfn_param["Default"] = default
                 cfn_param["Type"] = "String"
                 cfn_param["MinLength"] = 1
                 cfn_param["ConstraintDescription"] = "This parameter is required."
@@ -1216,7 +1371,7 @@ class rdk():
                 del source["SourceDetails"]
             else:
                 source["Owner"] = "CUSTOM_LAMBDA"
-                source["SourceIdentifier"] = { "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${LambdaAccountId}:function:RDK-Rule-Function-"+self.__get_alphanumeric_rule_name(rule_name) }
+                source["SourceIdentifier"] = { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${LambdaAccountId}:function:RDK-Rule-Function-"+self.__get_stack_name_from_rule_name(rule_name) }
 
             properties["Source"] = source
 
@@ -1252,9 +1407,20 @@ class rdk():
         template["Metadata"] = {
             "AWS::CloudFormation::Interface": {
                 "ParameterGroups": [
+                    {
+                        "Label": {
+                            "default": "Lambda Account ID"
+                        },
+                        "Parameters": [
+                            "LambdaAccountId"
+                        ]
+                    },
                     required_parameter_group,
                     optional_parameter_group
-                ]
+                ],
+                "ParameterLabels": {
+                    "LambdaAccountId": { "default": "REQUIRED: Account ID that contains Lambda Function(s) that back the Rules in this template."}
+                }
             }
         }
 
@@ -1272,7 +1438,7 @@ class rdk():
         else:
             print("Rule " + rulename + " is not in any RuleSets")
 
-        self.__write_params_file(rulename, params['Parameters'])
+        self.__write_params_file(rulename, params['Parameters'], params['Tags'])
 
         print(rulename + " removed from RuleSet " + ruleset)
 
@@ -1287,7 +1453,7 @@ class rdk():
             rulesets = [self.args.ruleset]
             params['Parameters']['RuleSets'] = rulesets
 
-        self.__write_params_file(rulename, params['Parameters'])
+        self.__write_params_file(rulename, params['Parameters'], params['Tags'])
 
         print(rulename + " added to RuleSet " + ruleset)
 
@@ -1318,7 +1484,7 @@ class rdk():
             deduped.sort()
             print("RuleSets: ", *deduped)
 
-    def __get_template_dir():
+    def __get_template_dir(self):
         return os.path.join(path.dirname(__file__), 'template')
 
     def __create_test_suite(self, test_dir):
@@ -1401,8 +1567,8 @@ class rdk():
                 logGroupName = self.__get_log_group_name(),
                 logStreamName = stream['logStreamName'],
                 limit = int(number_of_events)
-            )
 
+            )
             #Go through the logs and add events to my output array.
             for event in events['events']:
                 log_events.append(event)
@@ -1431,6 +1597,17 @@ class rdk():
             session_args['aws_secret_access_key']=self.args.secret_access_key
 
         return boto3.session.Session(**session_args)
+
+    def __get_caller_identity_details(self, session):
+        my_sts = session.client('sts')
+        response = my_sts.get_caller_identity()
+        arn_split = response['Arn'].split(':')
+
+        return {
+            'account_id': response['Account'],
+            'partition': arn_split[1],
+            'region': arn_split[3]
+        }
 
     def __get_stack_name_from_rule_name(self, rule_name):
         output = rule_name.replace("_","")
@@ -1491,28 +1668,14 @@ class rdk():
         parameters_file = open(params_file_path, 'r')
         my_json = json.load(parameters_file)
         parameters_file.close()
-        return my_json['Parameters']
+        my_tags = my_json.get('Tags', None)
+        if my_tags is not None:
+            #as my_tags is a list and thus returned as a string, convert it back to a list
+            my_tags = json.loads(my_tags)
+        return my_json['Parameters'], my_tags
 
     def __parse_rule_args(self, is_required):
-        usage_string = "[--runtime <runtime>] [--resource-types <resource types>] [--maximum-frequency <max execution frequency>] [--input-parameters <parameter JSON>] [--rulesets <RuleSet tags>]"
-
-        if is_required:
-            usage_string = "--runtime <runtime> [ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags] [--rulesets <RuleSet tags>]"
-
-        parser = argparse.ArgumentParser(
-            prog='rdk '+self.args.command,
-            usage="rdk "+self.args.command + " <rulename> " + usage_string
-        )
-        parser.add_argument('rulename', metavar='<rulename>', help='Rule name to create/modify')
-        runtime_group = parser.add_mutually_exclusive_group(required=is_required)
-        runtime_group.add_argument('-R','--runtime', required=False, help='Runtime for lambda function', choices=['nodejs4.3','java8','python2.7','python3.6','dotnetcore1.0','dotnetcore2.0'])
-        runtime_group.add_argument('--source-identifier', required=False, help="")
-        parser.add_argument('-r','--resource-types', required=False, help='Resource types that trigger event-based rule evaluation')
-        parser.add_argument('-m','--maximum-frequency', required=False, help='Maximum execution frequency', choices=['One_Hour','Three_Hours','Six_Hours','Twelve_Hours','TwentyFour_Hours'])
-        parser.add_argument('-i','--input-parameters', help="[optional] JSON for required Config parameters.")
-        parser.add_argument('--optional-parameters', help="[optional] JSON for optional Config parameters.")
-        parser.add_argument('-s','--rulesets', required=False, help='comma-delimited RuleSet names')
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_rule_parser(is_required, self.args.command).parse_args(self.args.command_args, self.args)
 
         resource_type_error = ""
         if self.args.resource_types:
@@ -1545,14 +1708,7 @@ class rdk():
             self.args.rulesets = self.args.rulesets.split(',')
 
     def __parse_test_args(self):
-        parser = argparse.ArgumentParser(prog='rdk '+self.args.command)
-        parser.add_argument('rulename', metavar='<rulename>[,<rulename>,...]', nargs='*', help='Rule name(s) to test')
-        parser.add_argument('--all','-a', action='store_true', help="Test will be run against all rules in the working directory.")
-        parser.add_argument('--test-ci-json', '-j', help="[optional] JSON for test CI for testing.")
-        parser.add_argument('--test-ci-types', '-t', help="[optional] CI type to use for testing.")
-        parser.add_argument('--verbose', '-v', action='store_true', help='Enable full log output')
-        parser.add_argument('-s','--rulesets', required=False, help='comma-delimited RuleSet names')
-        self.args = parser.parse_args(self.args.command_args, self.args)
+        self.args = get_test_parser(self.args.command).parse_args(self.args.command_args, self.args)
 
         if self.args.all and self.args.rulename:
             print("You may specify either specific rules or --all, but not both.")
@@ -1562,15 +1718,8 @@ class rdk():
             self.args.rulesets = self.args.rulesets.split(',')
 
     def __parse_deploy_args(self, ForceArgument=False):
-        parser = argparse.ArgumentParser(prog='rdk deploy')
-        parser.add_argument('rulename', metavar='<rulename>', nargs='*', help='Rule name(s) to deploy.  Rule(s) will be pushed to AWS.')
-        parser.add_argument('--all','-a', action='store_true', help="All rules in the working directory will be deployed.")
-        parser.add_argument('-s','--rulesets', required=False, help='comma-delimited RuleSet names')
-        parser.add_argument('-f','--functions-only', action='store_true', required=False, help="Only deploy Lambda functions.  Useful for cross-account deployments.")
-        parser.add_argument('--stack-name', required=False, help="Optional Stack name for use with --functions-only option.  If omitted, \"RDK-Config-Rule-Functions\" will be used." )
-        if ForceArgument:
-            parser.add_argument("--force", required=False, action='store_true', help='Remove selected Rules from account with prompting for confirmation.')
-        self.args = parser.parse_args(self.args.command_args, self.args)
+
+        self.args = get_deployment_parser(ForceArgument).parse_args(self.args.command_args, self.args)
 
         if self.args.stack_name and not self.args.functions_only:
             print("--stack-name can only be specified when using the --functions-only feature.")
@@ -1610,6 +1759,15 @@ class rdk():
             except Exception as e:
                 print("Error parsing optional input parameter JSON.  Make sure your JSON keys and values are enclosed in properly escaped double quotes and your optional-parameters string is enclosed in single quotes.")
 
+        my_tags = []
+
+        if self.args.tags:
+            #As above, but with the optional tag key value pairs.
+            try:
+                my_tags = json.loads(self.args.tags, strict=False)
+            except Exception as e:
+                print("Error parsing optional tags JSON.  Make sure your JSON keys and values are enclosed in properly escaped double quotes and tags string is enclosed in single quotes.")
+
         #create config file and place in rule directory
         parameters = {
             'RuleName': self.args.rulename,
@@ -1619,6 +1777,8 @@ class rdk():
             'InputParameters': json.dumps(my_input_params),
             'OptionalParameters': json.dumps(my_optional_params)
         }
+
+        tags = json.dumps(my_tags)
 
         if self.args.resource_types:
             parameters['SourceEvents'] = self.args.resource_types
@@ -1634,12 +1794,13 @@ class rdk():
             parameters['CodeKey'] = None
             parameters['SourceRuntime'] = None
 
-        self.__write_params_file(self.args.rulename, parameters)
+        self.__write_params_file(self.args.rulename, parameters, tags)
 
-    def __write_params_file(self, rulename, parameters):
+    def __write_params_file(self, rulename, parameters, tags):
         my_params = {
             "Version": "1.0",
-            "Parameters": parameters
+            "Parameters": parameters,
+            "Tags": tags
         }
         params_file_path = os.path.join(os.getcwd(), rules_dir, rulename, parameter_file_name)
         parameters_file = open(params_file_path, 'w')
@@ -1719,7 +1880,7 @@ class rdk():
             #    test_ci_list self._load_cis_from_file(tests_path)
             else:
                 print("\tTesting with generic CI for configured Resource Type(s)")
-                my_rule_params = self.__get_rule_parameters(rulename)
+                my_rule_params, my_rule_tags = self.__get_rule_parameters(rulename)
                 ci_types = str(my_rule_params['SourceEvents']).split(",")
                 for ci_type in ci_types:
                     my_test_ci = TestCI(ci_type)
@@ -1750,8 +1911,8 @@ class rdk():
 
         return my_lambda_arn
 
-    def __get_lambda_arn_for_rule(self, rule_name, region, account):
-        return "arn:aws:lambda:{}:{}:function:RDK-Rule-Function-{}".format(region, account, self.__get_alphanumeric_rule_name(rule_name))
+    def __get_lambda_arn_for_rule(self, rule_name, partition, region, account):
+        return "arn:{}:lambda:{}:{}:function:RDK-Rule-Function-{}".format(partition, region, account, self.__get_stack_name_from_rule_name(rule_name))
 
     def __delete_package_file(self, file):
         try:
@@ -1861,7 +2022,7 @@ class rdk():
                   "s3:GetObject"
                 ],
                 "Effect": "Allow",
-                "Resource": { "Fn::Join" : [ "/", [ "arn:aws:s3:::", { "Ref": "SourceBucket" }, "*" ] ] }
+                "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${SourceBucket}/*" }
               },
               {
                 "Sid": "2",
@@ -1903,13 +2064,14 @@ class rdk():
             ]
           }
         } ]
-        lambda_role["Properties"]["ManagedPolicyArns"] = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+        lambda_role["Properties"]["ManagedPolicyArns"] = [{"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess"}]
         resources["rdkLambdaRole"] = lambda_role
 
         rule_names = self.__get_rule_list_for_command()
         for rule_name in rule_names:
             alphanum_rule_name = self.__get_alphanumeric_rule_name(rule_name)
-            params = self.__get_rule_parameters(rule_name)
+            stack_name = self.__get_stack_name_from_rule_name(rule_name)
+            params, tags = self.__get_rule_parameters(rule_name)
 
             if 'SourceIdentifier' in params:
                 print("Skipping Managed Rule.")
@@ -1919,7 +2081,7 @@ class rdk():
             lambda_function["Type"] = "AWS::Lambda::Function"
             lambda_function["DependsOn"] = "rdkLambdaRole"
             properties = {}
-            properties["FunctionName"] = "RDK-Rule-Function-" + alphanum_rule_name
+            properties["FunctionName"] = "RDK-Rule-Function-" + stack_name
             properties["Code"] = {"S3Bucket": { "Ref": "SourceBucket"}, "S3Key": rule_name+"/"+rule_name+".zip"}
             properties["Description"] = "Function for AWS Config Rule " + rule_name
             properties["Handler"] = self.__get_handler(rule_name, params)

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -809,7 +809,15 @@ class rdk:
                 combined_input_parameters.update(json.loads(rule_params['InputParameters']))
 
             if 'OptionalParameters' in rule_params:
-                combined_input_parameters.update(json.loads(rule_params['OptionalParameters']))
+                #Remove empty parameters
+                keys_to_delete = []
+                optional_parameters_json = json.loads(rule_params['OptionalParameters'])
+                for key, value in optional_parameters_json.items():
+                    if not value:
+                        keys_to_delete.append(key)
+                for key in keys_to_delete:
+                    del optional_parameters_json[key]
+                combined_input_parameters.update(optional_parameters_json)
 
             if 'SourceIdentifier' in rule_params:
                 print("Found Managed Rule.")

--- a/rdk/template/configManagedRule.json
+++ b/rdk/template/configManagedRule.json
@@ -1,0 +1,66 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "AWS CloudFormation template to create Managed AWS Config rules. You will be billed for the AWS resources used if you create a stack from this template.",
+
+  "Parameters": {
+    "RuleName": {
+      "Description": "Name of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
+    "SourceEvents": {
+      "Description": "Event Type",
+      "Type": "CommaDelimitedList",
+      "Default": "NONE"
+    },
+    "SourcePeriodic": {
+      "Description": "Execution Frequency",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255",
+      "Default": "NONE"
+    },
+    "SourceIdentifier": {
+      "Description": "Source Identifier of Managed Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
+    "SourceInputParameters": {
+      "Description": "Input Parameters",
+      "Type": "String",
+      "Default": "{}"
+    },
+  },
+  "Conditions": {
+    "EventTriggered" : {"Fn::Not": [{ "Fn::Equals" : [{"Fn::Join": [",", { "Ref": "SourceEvents" }]}, "NONE"]}]},
+    "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]}
+  },
+  "Resources": {
+    "rdkConfigManagedRule": {
+      "Type": "AWS::Config::ConfigRule",
+      "Properties": {
+        "ConfigRuleName": { "Ref": "RuleName" },
+        "Description": { "Ref": "RuleName" },
+        "Scope": {
+          "Fn::If": [ "EventTriggered",
+            { "ComplianceResourceTypes": { "Ref": "SourceEvents" } },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "MaximumExecutionFrequency": {
+          "Fn::If": [ "PeriodicTriggered",
+            { "Ref": "SourcePeriodic" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "Source": {
+          "Owner": "AWS",
+          "SourceIdentifier": { "Ref": "SourceIdentifier" },
+        },
+        "InputParameters": { "Ref": "SourceInputParameters" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add the ability to deploy rules which are not Custom, allowing to centralize the management of the Rules (Custom and Managed) then deploy them through the same pipeline/command.
- Remove empty parameters value from OptionalParameters, since they are optional. Keeping track of the parameters in the parameters.json is practical.
- Update the copyright to 2019

Fix #124 