### PR TITLE
Improper sample-ci json found

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -65,7 +65,7 @@ accepted_resource_types = ['AWS::CloudFront::Distribution', 'AWS::CloudFront::St
                         'AWS::EC2::RouteTable', 'AWS::EC2::Subnet', 'AWS::EC2::VPC', 'AWS::EC2::VPNConnection', 'AWS::EC2::VPNGateway', 'AWS::AutoScaling::AutoScalingGroup', 'AWS::AutoScaling::LaunchConfiguration', 'AWS::AutoScaling::ScalingPolicy', 'AWS::AutoScaling::ScheduledAction', 'AWS::ACM::Certificate',
                         'AWS::CloudFormation::Stack', 'AWS::CloudTrail::Trail', 'AWS::CodeBuild::Project', 'AWS::ElasticBeanstalk::Application', 'AWS::ElasticBeanstalk::ApplicationVersion', 'AWS::ElasticBeanstalk::Environment', 'AWS::IAM::User', 'AWS::IAM::Group', 'AWS::IAM::Role', 'AWS::IAM::Policy', 'AWS::Lambda::Function',
                         'AWS::WAF::RateBasedRule', 'AWS::WAF::Rule', 'AWS::WAF::WebACL', 'AWS::WAF::RuleGroup', 'AWS::WAFRegional::RateBasedRule', 'AWS::WAFRegional::Rule', 'AWS::WAFRegional::WebACL', 'AWS::WAFRegional::RuleGroup', 'AWS::XRay::EncryptionConfig', 'AWS::ElasticLoadBalancingV2::LoadBalancer', 'AWS::ElasticLoadBalancing::LoadBalancer',
-                        'AWS::ElasticLoadBalancingV2::LoadBalancer']
+                        'AWS::ElasticLoadBalancingV2::LoadBalancer', 'AWS::SSM::ManagedInstanceInventory::Linux', 'AWS::SSM::ManagedInstanceInventory::Windows']
 
 def get_command_parser():
     #This is needed to get sphinx to auto-generate the CLI documentation correctly.

--- a/rdk/template/example_ci/AWS_SSM_ManagedInstanceInventory_Windows.json
+++ b/rdk/template/example_ci/AWS_SSM_ManagedInstanceInventory_Windows.json
@@ -48,1772 +48,1519 @@
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2894856",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Friday, June 20, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2896496",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 18, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2919355",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Tuesday, March 18, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2919442",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Saturday, May 17, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2920189",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Tuesday, January 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2934520",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2938066",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 18, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2938772",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Tuesday, March 18, 2014 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB2949621",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Saturday, May 17, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2954879",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Saturday, May 17, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2955164",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB2959626",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Friday, June 20, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2962409",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, January 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2962806",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, May 17, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2965500",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2967917",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Friday, June 20, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2969339",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2971203",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2973351",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Friday, June 20, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2973448",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, July 10, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2975061",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2975719",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2976627",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2977765",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2978041",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, November 18, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2978126",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2984006",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB2987107",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2989647",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, December 9, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2989930",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2993100",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2995004",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2995388",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB2996799",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, October 15, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2998174",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB2999226",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3000483",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, November 18, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3000850",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, November 18, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3003057",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, February 10, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3004361",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3004365",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB3004545",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, December 9, 2014 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3008923",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, December 9, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3012199",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3012702",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3013172",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, December 9, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3013769",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3013791",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, December 9, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3013816",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, November 18, 2014 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3014442",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, January 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3019978",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, February 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3020338",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3021910",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, February 10, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3021952",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3022345",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, January 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3022777",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3023222",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, January 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3023266",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3024751",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3024755",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3029603",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3030377",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3030947",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3032359",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3032663",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3033446",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3035126",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 10, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3036612",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3037579",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3037924",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3038002",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3038314",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB3038701",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3041857",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3042085",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3042553",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3044374",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3044673",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3045634",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3045685",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3045717",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3045719",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3045755",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3045992",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, April 15, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3045999",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3046017",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB3046737",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3048043",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3049563",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3054169",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3054203",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3054256",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3054464",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3055323",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3055343",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, May 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3055642",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3059316",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3059317",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3060681",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3060793",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3061512",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3063843",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3064209",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3068708",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3071756",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3074228",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3074548",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3075220",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3075853",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3077715",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, August 13, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3078071",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3078405",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3078676",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3080042",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3080149",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3082089",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3083325",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3083711",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3083992",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3084135",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3084905",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3086255",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3087038",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3087041",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3087137",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3091297",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, November 12, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3092601",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3092627",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3093983",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3094486",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3095701",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, October 22, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3096433",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, November 12, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3097997",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, November 12, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3098779",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3098785",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3099834",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3100473",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, November 12, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3100773",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3100919",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3100956",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3102429",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3102467",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, November 12, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3102812",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3103616",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3103696",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3103709",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3104002",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3109094",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3109103",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3109976",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, January 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3110329",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3112148",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, December 9, 2015 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3112336",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3115224",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3118401",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3121255",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3121261",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, January 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3121461",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, January 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3121918",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3122654",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3122660",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3123242",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3123245",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, January 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3123479",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, January 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3124275",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3125424",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3126033",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3126434",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3126587",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3126593",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3127226",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3127231",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3128650",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3133043",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3133681",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3133690",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3133924",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3134179",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3134242",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3134814",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3134815",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3135449",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3135456",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3135998",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3137061",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3137725",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3137728",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3138602",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3138615",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3139164",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3139398",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3139914",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, March 8, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3139929",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3140219",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3140234",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, February 11, 2016 12:00:00 AM",
             "Description": "Hotfix",
             "HotFixID": "KB3141092",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3142036",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3145384",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3145432",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3146604",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3146723",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3146751",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3146963",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3147071",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3148198",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3148851",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, April 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3149090",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3149157",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3153704",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3154070",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3155784",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3156016",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3156017",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3156019",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Thursday, May 12, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3156059",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3156418",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3159398",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3160005",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3161561",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3161949",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3161958",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3162343",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3162835",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3164024",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3164033",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3164035",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, June 15, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3164294",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3167679",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3169704",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3170377",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3170455",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3172614",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3172727",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3172729",
-            "InstalledBy": "WIN-61TNU83K1V4
-Administrator"
+            "InstalledBy": "WIN-61TNU83K1V4\\Administrator"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3173424",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3174644",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3175024",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3175443",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3175887",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3177108",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3177186",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3177723",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3177725",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Saturday, August 13, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3178034",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3178539",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3179574",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, October 11, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3179948",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, October 11, 2016 12:00:00 AM",
             "Description": "Update",
             "HotFixID": "KB3182203",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3184122",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3184943",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3185319",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Wednesday, September 14, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3185911",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           },
           {
             "InstalledTime": "Tuesday, October 11, 2016 12:00:00 AM",
             "Description": "Security Update",
             "HotFixID": "KB3185331",
-            "InstalledBy": "NT AUTHORITY
-SYSTEM"
+            "InstalledBy": "NT AUTHORITY\\SYSTEM"
           }
         ]
       },
@@ -1938,4 +1685,3 @@ SYSTEM"
   "messageType": "ConfigurationItemChangeNotification",
   "recordVersion": "1.2"
 }
-


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-config-rdk/issues/156

*Description of changes:*
[fix] - sample-ci for *AWS::SSM::ManagedInstanceInventory::Windows* json  
_[in-progress] - sample-ci for AWS::SSM::ManagedInstanceInventory::Linux
Redesign for sample-ci option, that accepts an optional flag_
`[--distro=Windows,Centos,AmazonLinux ... ].`

`rdk sample-ci AWS::SSM::ManagedInstanceInventory::Windows`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

