### PR TITLE
#169 - Fix for tagging lambda functions created by RDK

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2173,6 +2173,7 @@ class rdk:
             properties["Role"] = {"Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]}
             properties["Runtime"] = params["SourceRuntime"]
             properties["Timeout"] = 300
+            properties["Tags"] = tags
             lambda_function["Properties"] = properties
             resources[alphanum_rule_name+"LambdaFunction"] = lambda_function
 


### PR DESCRIPTION
*Issue #169:*

*Description of changes:*
Added the tags returned by the `def __create_function_cloudformation_template(self):` call to the cloud-formation template generated for the lambda template(s).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
