### PR TITLE
Avoid creation of config bucket if a delivery channel already exists

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -267,6 +267,7 @@ class rdk:
         delivery_channels = my_config.describe_delivery_channels()
         if len(delivery_channels['DeliveryChannels']) > 0:
             delivery_channel_exists = True
+            config_bucket_exists = True
             config_bucket_name = delivery_channels['DeliveryChannels'][0]['s3BucketName']
 
         my_s3 = my_session.client('s3')


### PR DESCRIPTION
*Issue #123 :*

*Description of changes:*
Set the config_bucket_exists flag to True if a delivery channel is found to avoid the creation of the config bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
