### PR TITLE
Feature:  Command line argument to create a ssm parameter based on stack name

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -154,7 +154,7 @@ def get_deployment_parser(ForceArgument=False, Command="deploy"):
     parser.add_argument('-s','--rulesets', required=False, help='comma-delimited list of RuleSet names')
     parser.add_argument('-f','--functions-only', action='store_true', required=False, help="[optional] Only deploy Lambda functions.  Useful for cross-account deployments.")
     parser.add_argument('--stack-name', required=False, help="[optional] CloudFormation Stack name for use with --functions-only option.  If omitted, \"RDK-Config-Rule-Functions\" will be used." )
-    parser.add_argument('--ssm-parameter', required=False, help="[optional] SSM parameter name that will store stack name, ie. /Test/IAD/CaC_Lambda_CFN")
+    parser.add_argument('--ssm-parameter', required=False, help="[optional] SSM parameter name that will store stack name, ie. /org/cac_compliace_ruleset_latest_installed/VALUE)
     if ForceArgument:
         parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
     return parser


### PR DESCRIPTION
Added the ability to name a SSM parameter with the stack name for reference purposes.

*Issue #, if available:*

*Description of changes:*
The following adds the ability to set a ssm parameter with the cloudformation stack name when using rdk in a pipeline that creates a stack-name that may have a dynamically created name.

The SSM parameter will be: /org/cac_compliace_ruleset_latest_installed/ with the name of the parameter.  The cac_compliace_ruleset_latest_installed, this value is static so 

The following command
```
rdk deploy -f --stack-name test --ssm-parameter demo 
```
will create a cfn template with a SSM parameter
/org/cac_compliace_ruleset_latest_installed/demo

When using rdk in a code pipeline references can be made to the SSM parameter.

For example:
```
STACKNAME=$(aws ssm get-parameters --names "/org/cac_compliace_ruleset_latest_installed/demo" | jq -r '.Parameters[0].Value')

rdk deploy --stack-name $STACKNAME -f --all 
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
