### PR TITLE
Add lambda role flag

### DIFF
--- a/docs/reference/create-rule-template.rst
+++ b/docs/reference/create-rule-template.rst
@@ -15,3 +15,5 @@ Create-Rule-Template
    The generated CloudFormation template includes a Parameter for the AccountID that contains the Lambda functions that provide the compliance logic for the Rules, and also exposes all of the Config Rule input parameters as CloudFormation stack parameters.
 
    By default the generated CloudFormation template will set up Config as per the settings used by the RDK ``init`` command, but those resources can be omitted using the ``--rules-only`` flag.
+
+   The ``--config-role-arn`` flag can be used for assigning existing config role to the created Configuration Recorder.

--- a/docs/reference/deploy.rst
+++ b/docs/reference/deploy.rst
@@ -11,6 +11,8 @@ Deploy
 
    Once deployed, RDK will _not_ explicitly start a Rule evaluation.  Depending on the changes being made to your Config Rule setup AWS Config may re-evaluate the deployed Rules automatically, or you can run an evaluation using the AWS configservice CLI.
 
+   The ``--lambda-role-arn`` flag can be used for assigning existing iam role to all Lambda functions created for Custom Config Rules.
+
    The ``--functions-only`` flag can be used as part of a multi-account deployment strategy to push _only_ the Lambda functions (and necessary Roles and Permssions) to the target account.  This is intended to be used in conjunction with the ``create-rule-template`` command in order to separate the compliance logic from the evaluated accounts.  For an example of how this looks in practice, check out the `AWS Compliance-as-Code Engine <https://github.com/awslabs/aws-config-engine-for-compliance-as-code/>`_.
 
    Note: Behind the scenes the ``--functions-only`` flag generates a CloudFormation template and runs a "create" or "update" on the targeted AWS Account and Region.  If subsequent calls to ``deploy`` with the ``--functions-only`` flag are made with the same stack name (either the default or otherwise) but with *different Config rules targeted*, any Rules deployed in previous ``deploy``s but not included in the latest ``deploy`` will be removed.  After a functions-only ``deploy`` _only_ the Rules specifically targeted by that command (either through Rulesets or an explicit list supplied on the command line) will be deployed in the environment, all others will be removed.s

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2067,11 +2067,6 @@ class rdk:
     def __create_function_cloudformation_template(self):
         print ("Generating CloudFormation template for Lambda Functions!")
 
-        lambda_role_arn = ""
-        if self.args.lambda_role_arn:
-            lambda_role_arn = self.args.lambda_role_arn
-            print ("Existing IAM role provided: " + lambda_role_arn)
-
         #First add the common elements - description, parameters, and resource section header
         template = {}
         template["AWSTemplateFormatVersion"] = "2010-09-09"
@@ -2088,7 +2083,10 @@ class rdk:
 
         resources = {}
 
-        if not lambda_role_arn:
+        if self.args.lambda_role_arn:
+            print ("Existing IAM role provided: " + self.args.lambda_role_arn)
+        else:
+            print ("No IAM role provided, creating a new IAM role for lambda function")
             lambda_role = {}
             lambda_role["Type"] = "AWS::IAM::Role"
             lambda_role["Properties"] = {}
@@ -2176,8 +2174,8 @@ class rdk:
             properties["Description"] = "Function for AWS Config Rule " + rule_name
             properties["Handler"] = self.__get_handler(rule_name, params)
             properties["MemorySize"] = "256"
-            if lambda_role_arn:
-                properties["Role"] = lambda_role_arn
+            if self.args.lambda_role_arn:
+                properties["Role"] = self.args.lambda_role_arn
             else:
                 lambda_function["DependsOn"] = "rdkLambdaRole"
                 properties["Role"] = {"Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]}

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -9,6 +9,10 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "LambdaRoleArn": {
+      "Description": "ARN of the existing IAM role that you want to attach to the lambda function.",
+      "Type": "String"
+    },
     "SourceBucket": {
       "Description": "Name of the S3 bucket that you have stored the rule zip files in.",
       "Type": "String",
@@ -55,6 +59,7 @@
     }
   },
   "Conditions": {
+    "CreateNewLambdaRole" : { "Fn::Equals" : [{ "Ref": "LambdaRoleArn" }, ""]},
     "EventTriggered" : {"Fn::Not": [{ "Fn::Equals" : [{"Fn::Join": [",", { "Ref": "SourceEvents" }]}, "NONE"]}]},
     "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]},
     "UseRDKLib": {"Fn::Not": [{"Fn::Equals": [{"Ref": "RDKLibVersion"}, "0"]}]}
@@ -71,7 +76,12 @@
         "Description": "Create a new AWS lambda function for rule code",
         "Handler": { "Ref": "SourceHandler"},
         "MemorySize": "256",
-        "Role":  { "Fn::GetAtt": [ "rdkLambdaRole", "Arn" ] } ,
+        "Role": {
+          "Fn::If": [ "CreateNewLambdaRole",
+              { "Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]},
+              { "Ref": "LambdaRoleArn" }
+            ]
+          },
         "Runtime": { "Ref": "SourceRuntime"},
         "Timeout": 60,
         "Layers": [
@@ -95,8 +105,7 @@
     "rdkConfigRule": {
       "Type": "AWS::Config::ConfigRule",
       "DependsOn": [
-        "ConfigPermissionToCallrdkRuleCodeLambda",
-        "rdkLambdaRole"
+        "ConfigPermissionToCallrdkRuleCodeLambda"
       ],
       "Properties": {
         "ConfigRuleName": { "Ref": "RuleName" },
@@ -132,6 +141,7 @@
       }
     },
     "rdkLambdaRole": {
+      "Condition": "CreateNewLambdaRole",
       "Type": "AWS::IAM::Role",
       "Properties": {
         "Path": "/rdk/",


### PR DESCRIPTION
*Issue #, if available:*
Create new deployment option for specifying custom rules lambda function role
*Description of changes:*
Adding a new flag, --lambda-role-arn, for "rdk deploy" command. This option will take the parameter IAM role ARN and attach it to all the custom rules lambda functions and deploy them to the associated account. This is very important for some infrastructure that requires highly secured IAM policies with minimized permission. With this feature, User can define their own policy/role and take full control of what permissions will be granted. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
