### PR TITLE
added additional command line arg so that its possible to run init, w…

### DIFF
--- a/docs/reference/init.rst
+++ b/docs/reference/init.rst
@@ -20,3 +20,7 @@ Init
    Note: Even without Config Rules running the Configuration Recorder is still capturing Configuration Item snapshots and storing them in S3, so running ``init`` will incur AWS charges!
 
    Also Note: AWS Config is a regional service, so running ``init`` will only set up Config in the region currently specified in your AWS_DEFAULT_REGION environment variable or in the ``--region`` flag.
+
+   Advanced Options:
+
+   - ``--config_bucket_exists_in_another_account``: If the bucket being used by a Config Delivery Channel exists in another account, it is possible to skip the check that the bucket exists. This is useful when using ``init`` to initialize AWS Config in an account which already has a delivery channel setup with a central bucket. Currently, the rdk lists out all the buckets within the account your are running ``init`` from, to check if the provided bucket name exists, if it doesn't then it will create it. This presents an issue when a Config Delivery Channel has been configured to push configuration recordings to a central bucket. The bucket will never be found as it doesn't exist in the same account, but cannot be created as bucket names have to be globally unique.

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -138,7 +138,10 @@ def get_command_parser():
 def get_init_parser():
     parser = argparse.ArgumentParser(
         prog='rdk init',
-        description = 'Sets up AWS Config.  This will enable configuration recording in AWS and ensure necessary S3 buckets and IAM Roles are created.')
+        description = 'Sets up AWS Config.  This will enable configuration recording in AWS and ensure necessary S3 buckets and IAM Roles are created.'
+    )
+
+    parser.add_argument('--config_bucket_exists_in_another_account', required=False, action='store_true', help='[optional] If the Config bucket exists in another account, remove the check of the bucket')
 
     return parser
 
@@ -301,7 +304,12 @@ class rdk:
         config_recorder_name = "default"
         config_role_arn = ""
         delivery_channel_exists = False
+
         config_bucket_exists = False
+        if self.args.config_bucket_exists_in_another_account:
+            print("Skipping Config Bucket check due to command line args")
+            config_bucket_exists = True
+
         config_bucket_name = config_bucket_prefix + "-" + account_id
 
         #Check to see if the ConfigRecorder has been created.


### PR DESCRIPTION
…hen the bucket belongs to another account

Signed-off-by: jack1902 <39212456+jack1902@users.noreply.github.com>

*Issue #, if available:*
Fixes https://github.com/awslabs/aws-config-rdk/issues/123

*Description of changes:*
Added an additional command line arg, which allows the user to state that the bucket is deployed to another account. This will skip the listing of buckets within the current account where init is being ran from, as it might not be possible to verify the bucket exists with the current credentials the user has.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
