### PR TITLE
Fix/oversized item summary

### DIFF
--- a/rdk/template/runtime/python3.6/rule_code.py
+++ b/rdk/template/runtime/python3.6/rule_code.py
@@ -220,7 +220,7 @@ def convert_api_configuration(configuration_item):
 def get_configuration_item(invoking_event):
     check_defined(invoking_event, 'invokingEvent')
     if is_oversized_changed_notification(invoking_event['messageType']):
-        configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
+        configuration_item_summary = check_defined(invoking_event['configurationItemSummary'], 'configurationItemSummary')
         return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
     if is_scheduled_notification(invoking_event['messageType']):
         return None

--- a/rdk/template/runtime/python3.7/rule_code.py
+++ b/rdk/template/runtime/python3.7/rule_code.py
@@ -220,7 +220,7 @@ def convert_api_configuration(configuration_item):
 def get_configuration_item(invoking_event):
     check_defined(invoking_event, 'invokingEvent')
     if is_oversized_changed_notification(invoking_event['messageType']):
-        configuration_item_summary = check_defined(invoking_event['configuration_item_summary'], 'configurationItemSummary')
+        configuration_item_summary = check_defined(invoking_event['configurationItemSummary'], 'configurationItemSummary')
         return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
     if is_scheduled_notification(invoking_event['messageType']):
         return None


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-config-rdk/issues/186
*Description of changes:*
Updated the template code for python3.6 and 3.7 to match the other templates for python3.6-managed and 2.7. These both have the same dictionary looked which is detailed in the docs:

https://docs.aws.amazon.com/config/latest/developerguide/oversized-notification-example.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
