### PR TITLE
fix lambda function runtime for rdklib implementation

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2358,7 +2358,7 @@ class rdk:
             else:
                 lambda_function["DependsOn"] = "rdkLambdaRole"
                 properties["Role"] = {"Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]}
-            properties["Runtime"] = params["SourceRuntime"]
+            properties["Runtime"] = self.__get_runtime_string(params)
             properties["Timeout"] = 300
             properties["Tags"] = tags
             layers = []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To enable the use of RDKLib, source runtime should be set as python3.6-lib in parameter.json. However, when we do "rdk deploy -f", it is not modified to be "python3.6" for lambda function setting in cloudformation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
