### PR TITLE
[NEW FEATURE] Create RDK Lambda functions within VPC

### DIFF
--- a/docs/reference/deploy.rst
+++ b/docs/reference/deploy.rst
@@ -14,8 +14,8 @@ Deploy
    The ``--functions-only`` flag can be used as part of a multi-account deployment strategy to push _only_ the Lambda functions (and necessary Roles and Permssions) to the target account.  This is intended to be used in conjunction with the ``create-rule-template`` command in order to separate the compliance logic from the evaluated accounts.  For an example of how this looks in practice, check out the `AWS Compliance-as-Code Engine <https://github.com/awslabs/aws-config-engine-for-compliance-as-code/>`_.
    The ``--rdklib-layer-arn`` flag can be used for attaching Lambda Layer ARN that contains the desired rdklib.  Note that Lambda Layers are region-specific.
    The ``--lambda-role-arn`` flag can be used for assigning existing iam role to all Lambda functions created for Custom Config Rules.
-   The ``--lambda-layers`` flag can be used for attaching comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).
-   The ``--lambda-subnets`` flag can be used for attaching comma-separated list of Subnets to deploy your Lambda function(s).
-   The ``--lambda-security-groups`` flag can be used for attaching comma-separated list of Security Groups to deploy with your Lambda function(s).
+   The ``--lambda-layers`` flag can be used for attaching a comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).
+   The ``--lambda-subnets`` flag can be used for attaching a comma-separated list of Subnets to deploy your Lambda function(s).
+   The ``--lambda-security-groups`` flag can be used for attaching a comma-separated list of Security Groups to deploy with your Lambda function(s).
 
    Note: Behind the scenes the ``--functions-only`` flag generates a CloudFormation template and runs a "create" or "update" on the targeted AWS Account and Region.  If subsequent calls to ``deploy`` with the ``--functions-only`` flag are made with the same stack name (either the default or otherwise) but with *different Config rules targeted*, any Rules deployed in previous ``deploy``s but not included in the latest ``deploy`` will be removed.  After a functions-only ``deploy`` _only_ the Rules specifically targeted by that command (either through Rulesets or an explicit list supplied on the command line) will be deployed in the environment, all others will be removed.s

--- a/docs/reference/deploy.rst
+++ b/docs/reference/deploy.rst
@@ -11,8 +11,11 @@ Deploy
 
    Once deployed, RDK will _not_ explicitly start a Rule evaluation.  Depending on the changes being made to your Config Rule setup AWS Config may re-evaluate the deployed Rules automatically, or you can run an evaluation using the AWS configservice CLI.
 
-   The ``--lambda-role-arn`` flag can be used for assigning existing iam role to all Lambda functions created for Custom Config Rules.
-
    The ``--functions-only`` flag can be used as part of a multi-account deployment strategy to push _only_ the Lambda functions (and necessary Roles and Permssions) to the target account.  This is intended to be used in conjunction with the ``create-rule-template`` command in order to separate the compliance logic from the evaluated accounts.  For an example of how this looks in practice, check out the `AWS Compliance-as-Code Engine <https://github.com/awslabs/aws-config-engine-for-compliance-as-code/>`_.
+   The ``--rdklib-layer-arn`` flag can be used for attaching Lambda Layer ARN that contains the desired rdklib.  Note that Lambda Layers are region-specific.
+   The ``--lambda-role-arn`` flag can be used for assigning existing iam role to all Lambda functions created for Custom Config Rules.
+   The ``--lambda-layers`` flag can be used for attaching comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).
+   The ``--lambda-subnets`` flag can be used for attaching comma-separated list of Subnets to deploy your Lambda function(s).
+   The ``--lambda-security-groups`` flag can be used for attaching comma-separated list of Security Groups to deploy with your Lambda function(s).
 
    Note: Behind the scenes the ``--functions-only`` flag generates a CloudFormation template and runs a "create" or "update" on the targeted AWS Account and Region.  If subsequent calls to ``deploy`` with the ``--functions-only`` flag are made with the same stack name (either the default or otherwise) but with *different Config rules targeted*, any Rules deployed in previous ``deploy``s but not included in the latest ``deploy`` will be removed.  After a functions-only ``deploy`` _only_ the Rules specifically targeted by that command (either through Rulesets or an explicit list supplied on the command line) will be deployed in the environment, all others will be removed.s

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,4 +6,4 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.6.4"
+MY_VERSION = "0.7.0"

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2358,7 +2358,7 @@ class rdk:
             else:
                 lambda_function["DependsOn"] = "rdkLambdaRole"
                 properties["Role"] = {"Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]}
-            properties["Runtime"] = params["SourceRuntime"]
+            properties["Runtime"] = self.__get_runtime_string(params)
             properties["Timeout"] = 300
             properties["Tags"] = tags
             layers = []

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2298,7 +2298,7 @@ class rdk:
                 "Action": "sts:AssumeRole"
               } ]
             }
-            lambda_statement =[
+            lambda_policy_statements =[
                 {
                     "Sid": "1",
                     "Action": [
@@ -2356,12 +2356,12 @@ class rdk:
                     "Effect": "Allow",
                     "Resource": "*"
                 }
-                lambda_statement.append(vpc_policy)
+                lambda_policy_statements.append(vpc_policy)
             lambda_role["Properties"]["Policies"] = [{
               "PolicyName": "ConfigRulePolicy",
               "PolicyDocument": {
                 "Version": "2012-10-17",
-                "Statement": lambda_statement
+                "Statement": lambda_policy_statements
               }
             } ]
             lambda_role["Properties"]["ManagedPolicyArns"] = [{"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess"}]

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -216,11 +216,12 @@ def get_deployment_parser(ForceArgument=False, Command="deploy"):
     parser.add_argument('--all','-a', action='store_true', help="All rules in the working directory will be deployed.")
     parser.add_argument('-s','--rulesets', required=False, help='comma-delimited list of RuleSet names')
     parser.add_argument('-f','--functions-only', action='store_true', required=False, help="[optional] Only deploy Lambda functions.  Useful for cross-account deployments.")
-    parser.add_argument('--lambda-role-arn', required=False, help="[optional] Assign existing iam role to lambda functions. If omitted, \"rdkLambdaRole\" will be created.")
     parser.add_argument('--stack-name', required=False, help="[optional] CloudFormation Stack name for use with --functions-only option.  If omitted, \"RDK-Config-Rule-Functions\" will be used." )
-    parser.add_argument('--execution-role-name', required=False, help="[optional] IAM Role that the Lambda function(s) will assume in each target account.")
     parser.add_argument('--rdklib-layer-arn', required=False, help="[optional] Lambda Layer ARN that contains the desired rdklib.  Note that Lambda Layers are region-specific.")
+    parser.add_argument('--lambda-role-arn', required=False, help="[optional] Assign existing iam role to lambda functions. If omitted, \"rdkLambdaRole\" will be created.")
     parser.add_argument('--lambda-layers', required=False, help="[optional] Comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).")
+    parser.add_argument('--lambda-subnets', required=False, help="[optional] Comma-separated list of Subnets to deploy your Lambda function(s).")
+    parser.add_argument('--lambda-security-groups', required=False, help="[optional] Comma-separated list of Security Groups to deploy with your Lambda function(s).")
 
     if ForceArgument:
         parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
@@ -1059,14 +1060,22 @@ class rdk:
 
 
             if self.args.lambda_layers:
-                if self.args.lambda_layers:
-                    additional_layers = self.args.lambda_layers.split(',')
-                    layers.extend(additional_layers)
+                additional_layers = self.args.lambda_layers.split(',')
+                layers.extend(additional_layers)
 
             if layers:
                 my_params.append({
                     'ParameterKey': 'Layers',
                     'ParameterValue': ",".join(layers)
+                })
+
+            if self.args.lambda_security_groups and self.args.lambda_subnets:
+                my_params.append({
+                    'ParameterKey': 'SecurityGroupIds',
+                    'ParameterValue': self.args.lambda_security_groups
+                },{
+                    'ParameterKey': 'SubnetIds',
+                    'ParameterValue': self.args.lambda_subnets
                 })
 
             #create json of CFN template
@@ -2289,57 +2298,70 @@ class rdk:
                 "Action": "sts:AssumeRole"
               } ]
             }
+            lambda_statement =[
+                {
+                    "Sid": "1",
+                    "Action": [
+                        "s3:GetObject"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${SourceBucket}/*" }
+                },
+                {
+                    "Sid": "2",
+                    "Action": [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents",
+                        "logs:DescribeLogStreams"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                },
+                {
+                    "Sid": "3",
+                    "Action": [
+                        "config:PutEvaluations"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                },
+                {
+                    "Sid": "4",
+                    "Action": [
+                        "iam:List*",
+                        "iam:Describe*",
+                        "iam:Get*"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                },
+                {
+                    "Sid": "5",
+                    "Action": [
+                        "sts:AssumeRole"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                }
+            ]
+            if self.args.lambda_subnets and self.args.lambda_security_groups:
+                vpc_policy={
+                    "Sid": "LambdaVPCAccessExecution",
+                    "Action": [
+                        "ec2:DescribeNetworkInterfaces",
+                        "ec2:DeleteNetworkInterface",
+                        "ec2:CreateNetworkInterface"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": "*"
+                }
+                lambda_statement.append(vpc_policy)
             lambda_role["Properties"]["Policies"] = [{
               "PolicyName": "ConfigRulePolicy",
               "PolicyDocument": {
                 "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Sid": "1",
-                    "Action": [
-                      "s3:GetObject"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": { "Fn::Sub": "arn:${AWS::Partition}:s3:::${SourceBucket}/*" }
-                  },
-                  {
-                    "Sid": "2",
-                    "Action": [
-                      "logs:CreateLogGroup",
-                      "logs:CreateLogStream",
-                      "logs:PutLogEvents",
-                      "logs:DescribeLogStreams"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": "*"
-                  },
-                  {
-                    "Sid": "3",
-                    "Action": [
-                      "config:PutEvaluations"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": "*"
-                  },
-                  {
-                    "Sid": "4",
-                    "Action": [
-                      "iam:List*",
-                      "iam:Describe*",
-                      "iam:Get*"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": "*"
-                  },
-                  {
-                    "Sid": "5",
-                    "Action": [
-                      "sts:AssumeRole"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": "*"
-                  }
-                ]
+                "Statement": lambda_statement
               }
             } ]
             lambda_role["Properties"]["ManagedPolicyArns"] = [{"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess"}]
@@ -2371,6 +2393,11 @@ class rdk:
             properties["Runtime"] = self.__get_runtime_string(params)
             properties["Timeout"] = 300
             properties["Tags"] = tags
+            if self.args.lambda_subnets and self.args.lambda_security_groups:
+                properties["VpcConfig"] = {
+                    "SecurityGroupIds" : self.args.lambda_security_groups.split(","),
+                    "SubnetIds" : self.args.lambda_subnets.split(",")
+                }
             layers = []
             if self.args.rdklib_layer_arn:
                 layers.append(self.args.rdklib_layer_arn)

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -75,7 +75,7 @@
     "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]},
     "UseAdditionalLayers": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Layers"}, ""]}]},
     "UseVpcConfig": {
-      "Fn:And": [
+      "Fn::And": [
         {"Fn::Not": [{"Fn::Equals": [{"Ref": "SecurityGroupIds"}, ""]}]},
         {"Fn::Not": [{"Fn::Equals": [{"Ref": "SubnetIds"}, ""]}]}
       ]

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -57,13 +57,29 @@
       "Description": "Comma-separated list of Lambda layers to be included with Lambda Function deployment",
       "Type": "String",
       "Default": ""
+    },
+    "SecurityGroupIds": {
+      "Description": "Comma-separated list of Security Group Ids for Lambda Function deployment",
+      "Type": "String",
+      "Default": ""
+    },
+    "SubnetIds": {
+      "Description": "Comma-separated list of Subnet Ids for Lambda Function deployment",
+      "Type": "String",
+      "Default": ""
     }
   },
   "Conditions": {
     "CreateNewLambdaRole" : { "Fn::Equals" : [{ "Ref": "LambdaRoleArn" }, ""]},
     "EventTriggered" : {"Fn::Not": [{ "Fn::Equals" : [{"Fn::Join": [",", { "Ref": "SourceEvents" }]}, "NONE"]}]},
     "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]},
-    "UseAdditionalLayers": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Layers"}, ""]}]}
+    "UseAdditionalLayers": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Layers"}, ""]}]},
+    "UseVpcConfig": {
+      "Fn:And": [
+        {"Fn::Not": [{"Fn::Equals": [{"Ref": "SecurityGroupIds"}, ""]}]},
+        {"Fn::Not": [{"Fn::Equals": [{"Ref": "SubnetIds"}, ""]}]}
+      ]
+    }
   },
   "Resources": {
     "rdkRuleCodeLambda": {
@@ -89,6 +105,16 @@
           {"Fn::If":
             [ "UseAdditionalLayers",
               { "Fn::Split": [",", {"Ref": "Layers"}]},
+              { "Ref": "AWS::NoValue"}
+            ]
+          },
+        "VpcConfig":
+          {"Fn::If":
+            [ "UseVpcConfig",
+              {
+                "SecurityGroupIds": {"Fn::Split": [",", {"Ref": "SecurityGroupIds"}]},
+                "SubnetIds": {"Fn::Split": [",", {"Ref": "SubnetIds"}]}
+              },
               { "Ref": "AWS::NoValue"}
             ]
           }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For security purpose, all lambda functions should be created within VPC. Adding ability to provide VPC information to RDK lambda cloudformation template. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
