### PR TITLE
Fix issues within RDK deploy & remediation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,12 @@ version = u''
 # The full version, including alpha/beta/rc tags
 release = u'1.0'
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # -- General configuration ---------------------------------------------------
 
@@ -82,7 +88,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+# html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -196,7 +196,6 @@ def get_rule_parser(is_required, command):
     parser.add_argument('--auto-remediation-retry-time', required=False, help='[optional] Duration of automated remediation retries.')
     parser.add_argument('--remediation-concurrent-execution-percent', required=False, help='[optional] Concurrent execution rate of the SSM document for remediation.')
     parser.add_argument('--remediation-error-rate-percent', required=False, help='[optional] Error rate that will mark the batch as "failed" for SSM remediation execution.')
-    parser.add_argument('--remediation-resource-id-parameter', required=False, help='[optional] Parameter that will be passed to SSM remediation document.')
     parser.add_argument('--remediation-parameters', required=False, help='[optional] JSON-formatted string of additional parameters required by the SSM document.')
     return parser
 
@@ -2085,8 +2084,7 @@ class rdk:
                     "remediation_action_version",
                     "remediation_concurrent_execution_percent",
                     "remediation_error_rate_percent",
-                    "remediation_parameters",
-                    "remediation_resource_id_parameter"
+                    "remediation_parameters"
                 ]
             )
             and not self.args.remediation_action

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -825,6 +825,8 @@ class rdk:
                     s3_dst = self.__upload_function_code(rule_name, rule_params, account_id, my_session, code_bucket_name)
                     s3_code_objects[rule_name] = s3_dst
 
+            my_cfn = my_session.client('cloudformation')
+
             # Generate the template_url regardless of region using the s3 sdk
             config = my_s3_client._client_config
             config.signature_version = botocore.UNSIGNED

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -703,7 +703,8 @@ class rdk:
                 ssm_controls = execution_controls["SsmControls"]
                 self.args.remediation_concurrent_execution_percent = ssm_controls.get("ConcurrentExecutionRatePercentage", "")
                 self.args.remediation_error_rate_percent = ssm_controls.get("ErrorPercentage", "")
-            self.args.remediation_parameters = json.dumps(params.get("Parameters", ""))
+            self.args.remediation_parameters = json.dumps(params["Parameters"]) if params.get("Parameters") else None
+            self.args.auto_remediation_retry_attempts = params.get("MaximumAutomaticAttempts", "")
             self.args.auto_remediation_retry_time = params.get("RetryAttemptSeconds", "")
             self.args.remediation_action = params.get("TargetId", "")
             self.args.remediation_action_version = params.get("TargetVersion", "")

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -151,7 +151,7 @@ def get_init_parser():
         description = 'Sets up AWS Config.  This will enable configuration recording in AWS and ensure necessary S3 buckets and IAM Roles are created.'
     )
 
-    parser.add_argument('--config_bucket_exists_in_another_account', default=False, required=False, action='store_true', help='[optional] If the Config bucket exists in another account, remove the check of the bucket')
+    parser.add_argument('--config-bucket-exists-in-another-account', default=False, required=False, action='store_true', help='[optional] If the Config bucket exists in another account, remove the check of the bucket')
 
     return parser
 

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -524,7 +524,7 @@ class rdk:
             except Exception as e:
                 print("Error encountered removing Config Role: " + str(e))
         except Exception as e2:
-            print("Error encountered finding Config Role to remove: " + str(e))
+            print("Error encountered finding Config Role to remove: " + str(e2))
 
         config_bucket_names = []
         delivery_channels = my_config.describe_delivery_channels()

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2076,6 +2076,23 @@ class rdk:
                 print("Error parsing optional tags JSON.  Make sure your JSON keys and values are enclosed in properly escaped double quotes and tags string is enclosed in single quotes.")
 
         my_remediation = {}
+        if (
+            any(
+                getattr(self.args, arg) is not None
+                for arg in [
+                    "auto_remediation_retry_attempts",
+                    "auto_remediation_retry_time",
+                    "remediation_action_version",
+                    "remediation_concurrent_execution_percent",
+                    "remediation_error_rate_percent",
+                    "remediation_parameters",
+                    "remediation_resource_id_parameter"
+                ]
+            )
+            and not self.args.remediation_action
+        ):
+            print("Remediation Flags detected but no remeditaion action (--remediation-action) set")
+
         if self.args.remediation_action:
             try:
                 my_remediation = self.__generate_remediation_params()

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -150,7 +150,7 @@ def get_init_parser():
         description = 'Sets up AWS Config.  This will enable configuration recording in AWS and ensure necessary S3 buckets and IAM Roles are created.'
     )
 
-    parser.add_argument('--config_bucket_exists_in_another_account', required=False, action='store_true', help='[optional] If the Config bucket exists in another account, remove the check of the bucket')
+    parser.add_argument('--config_bucket_exists_in_another_account', default=False, required=False, action='store_true', help='[optional] If the Config bucket exists in another account, remove the check of the bucket')
 
     return parser
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-e .
+sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
*Issue #, if available:*

resolves: #224 #225 #226 #229
relates to: #218 

In regards to #218, this is workaround because the documentation on ReadTheDocs is pointing at a different repo

*Description of changes:*

Previously there were multiple bugs within the `rdk` that meant `modify` wasn't respecting previously created rules `parameters.json`. I have also included numerous other fixes around the `rdk` when using it to generate the CloudFormation for multi-account deployments.

These issues have been fixed by:

* Removing `--remediation-resource-id-parameter` This flag did nothing

* Changing how `remediation_parameters` was calculated. Previously if you didn't set these on `create`, `Parameters` wouldn't show up in the JSON file, this was expected behaviour. If you then ran `modify` the `json.dumps()` would become `'""'` which evaluates to `True` which caused a blank `Parameters` to be placed in the JSON file.

* Print out an error message when any remediation flags were passed without a `--remediation-action` as to reduce confusion as to why things weren't turning up in the JSON file

* set default: `False` for `--config-bucket-exists-in-another-account` as i was observing error on the command line. EDIT: Updated so command is consistent with other flags

* Added `--remediation-role-name` flag so that it is possible to give a role name without specifying the full ARN which wouldn't work on multi-accounts deployments

* Using the S3 SDK to generate a URL for use with the CloudFormation deployment. resolves #229 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
