### PR TITLE
REALEASE 0.7.5 Add tags to 'deploy' config rule and generate script for adding config rule tags on 'create-rule-template'

### DIFF
--- a/docs/reference/create-rule-template.rst
+++ b/docs/reference/create-rule-template.rst
@@ -17,5 +17,6 @@ Create-Rule-Template
    By default the generated CloudFormation template will set up Config as per the settings used by the RDK ``init`` command, but those resources can be omitted using the ``--rules-only`` flag.
 
    The ``--config-role-arn`` flag can be used for assigning existing config role to the created Configuration Recorder.
+   The ``-t | --tag-config-rules-script <file path>`` can now be used for output the script generated for create tags for each config rule.
 
    As of version 0.6, RDK supports Config remediation.  Note that in order to use SSM documents for remediation you must supply all of the necessary document parameters.  These can be found in the SSM document listing on the AWS console, but RDK will *not* validate at rule creation that you have all of the necessary parameters supplied.

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,4 +6,4 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.7.4"
+MY_VERSION = "0.7.5"

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1456,7 +1456,7 @@ class rdk:
         if self.args.rulesets:
             self.args.rulesets = self.args.rulesets.split(',')
 
-        script_for_tag="#! /bin/bash \n"
+        script_for_tag=""
 
         print ("Generating CloudFormation template!")
 
@@ -1699,9 +1699,10 @@ class rdk:
         output_file.write(json.dumps(template, indent=2))
         print("CloudFormation template written to " + self.args.output_file)
 
-        if tags:
+        if script_for_tag:
             print ("Found tags on config rules. Cloudformation do not support tagging config rule at the moment")
             print ("Generating script for config rules tags")
+            script_for_tag= "#! /bin/bash \n" + script_for_tag
             if self.args.tag_config_rules_script:
                 with open (self.args.tag_config_rules_script, 'w') as rsh:
                     rsh.write(script_for_tag)

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -188,7 +188,7 @@ def get_rule_parser(is_required, command):
     usage_string = "[--runtime <runtime>] [--resource-types <resource types>] [--maximum-frequency <max execution frequency>] [--input-parameters <parameter JSON>] [--tags <tags JSON>] [--rulesets <RuleSet tags>]"
 
     if is_required:
-        usage_string = "[ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags] [--rulesets <RuleSet tags>]"
+        usage_string = "[ --resource-types <resource types> | --maximum-frequency <max execution frequency> ] [optional configuration flags] [--runtime <runtime>] [--rulesets <RuleSet tags>]"
 
     parser = argparse.ArgumentParser(
         prog='rdk '+command,
@@ -1093,7 +1093,7 @@ class rdk:
                     self.__wait_for_cfn_stack(my_cfn, my_stack_name)
 
                 #Cloudformation is not supporting tagging config rule currently.
-                if cfn_tags is not None:
+                if cfn_tags is not None and len(cfn_tags) > 0:
                     self.__tag_config_rule(rule_name, cfn_tags, my_session)
 
                 continue
@@ -1252,7 +1252,7 @@ class rdk:
             self.__wait_for_cfn_stack(my_cfn, my_stack_name)
 
             #Cloudformation is not supporting tagging config rule currently.
-            if cfn_tags is not None:
+            if cfn_tags is not None and len(cfn_tags) > 0:
                 self.__tag_config_rule(rule_name, cfn_tags, my_session)
 
         print('Config deploy complete.')

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1709,7 +1709,7 @@ class rdk:
             else:
                 print("=========SCRIPT=========")
                 print(script_for_tag)
-                print("you can use flag [--tag_config_rules_script <file path> ] to output the script")
+                print("you can use flag [--tag-config-rules-script <file path> ] to output the script")
 
     def __generate_terraform_shell(self, args):
         return ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. "rdk deploy" now support tagging config rules. 
2. "rdk create-rule-template" now generates a script for user to execute in order to create tags for each config rule. In addition, You can output the script in file with "-t | --tag-config-rules-script <file path>"
*Cloudformation is not supporting tagging config rule resources at the moment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
