### PR TITLE
Implements a --boundary-policy-arn argument for `rdk deploy`

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -243,6 +243,7 @@ def get_deployment_parser(ForceArgument=False, Command="deploy"):
     parser.add_argument('--lambda-layers', required=False, help="[optional] Comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).")
     parser.add_argument('--lambda-subnets', required=False, help="[optional] Comma-separated list of Subnets to deploy your Lambda function(s).")
     parser.add_argument('--lambda-security-groups', required=False, help="[optional] Comma-separated list of Security Groups to deploy with your Lambda function(s).")
+    parser.add_argument('--boundary-policy-arn', required=False, help="[optional] Boundary Policy ARN that will be added to \"rdkLambdaRole\".")
 
     if ForceArgument:
         parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
@@ -1163,6 +1164,10 @@ class rdk:
                 print ("Existing IAM Role provided: " + self.args.lambda_role_arn)
                 lambdaRoleArn = self.args.lambda_role_arn
 
+            if self.args.boundary_policy_arn:
+                print ("Boundary Policy provided: " + self.args.boundary_policy_arn)
+                boundaryPolicyArn = self.args.boundary_policy_arn
+
             my_params = [
                 {
                     'ParameterKey': 'RuleName',
@@ -1171,6 +1176,10 @@ class rdk:
                 {
                     'ParameterKey': 'LambdaRoleArn',
                     'ParameterValue': lambdaRoleArn,
+                },
+                {
+                    'ParameterKey': 'BoundaryPolicyArn',
+                    'ParameterValue': boundaryPolicyArn,
                 },
                 {
                     'ParameterKey': 'SourceBucket',

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -14,6 +14,11 @@
       "Type": "String",
       "Default": ""
     },
+    "BoundaryPolicyArn": {
+      "Description": "ARN of a Boundary Policy, will be used only if LambdaRoleArn is NOT set.",
+      "Type": "String",
+      "Default": ""
+    },
     "SourceBucket": {
       "Description": "Name of the S3 bucket that you have stored the rule zip files in.",
       "Type": "String",
@@ -71,6 +76,7 @@
   },
   "Conditions": {
     "CreateNewLambdaRole" : { "Fn::Equals" : [{ "Ref": "LambdaRoleArn" }, ""]},
+    "UseBoundaryPolicyInRole" : {"Fn::Not":[{ "Fn::Equals" : [{ "Ref": "BoundaryPolicyArn" }, ""]}]},
     "EventTriggered" : {"Fn::Not": [{ "Fn::Equals" : [{"Fn::Join": [",", { "Ref": "SourceEvents" }]}, "NONE"]}]},
     "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]},
     "UseAdditionalLayers": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Layers"}, ""]}]},
@@ -172,6 +178,11 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "Path": "/rdk/",
+        "PermissionsBoundary": {"Fn::If": [ "UseBoundaryPolicyInRole",
+            { "Ref": "BoundaryPolicyArn" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [ {


### PR DESCRIPTION
Allow deployers to specify a --boundary-policy-arn, which gets injected into the generated AWS::IAM::Role, as [PermissionsBoundary](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary). 

*Issue #, if available:*

#264

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
