### PR TITLE
Add rule description into rule parameters

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -995,6 +995,10 @@ class rdk:
                         'ParameterValue': rule_name,
                     },
                     {
+                        'ParameterKey': 'Description',
+                        'ParameterValue': rule_params["Description"],
+                    },
+                    {
                         'ParameterKey': 'SourceEvents',
                         'ParameterValue': source_events,
                     },
@@ -1167,6 +1171,10 @@ class rdk:
                 {
                     'ParameterKey': 'RuleName',
                     'ParameterValue': rule_name,
+                },
+                {
+                    'ParameterKey': 'Description',
+                    'ParameterValue': rule_params["Description"],
                 },
                 {
                     'ParameterKey': 'LambdaRoleArn',
@@ -1780,7 +1788,7 @@ class rdk:
             source["SourceDetails"] = []
 
             properties["ConfigRuleName"] = rule_name
-            properties["Description"] = rule_name
+            properties["Description"] = params["Description"]
 
             #Create the SourceDetails stanza.
             if 'SourceEvents' in params:
@@ -2423,6 +2431,7 @@ class rdk:
         #create config file and place in rule directory
         parameters = {
             'RuleName': self.args.rulename,
+            'Description': self.args.rulename,
             'SourceRuntime': self.args.runtime,
             #'CodeBucket': code_bucket_prefix + account_id,
             'CodeKey': self.args.rulename+'.zip',

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -989,6 +989,10 @@ class rdk:
                 print("Found Managed Rule.")
                 #create CFN Parameters for Managed Rules
 
+                try:
+                    rule_description = rule_params["Description"]
+                except KeyError:
+                    rule_description = rule_name
                 my_params = [
                     {
                         'ParameterKey': 'RuleName',
@@ -996,7 +1000,7 @@ class rdk:
                     },
                     {
                         'ParameterKey': 'Description',
-                        'ParameterValue': rule_params["Description"],
+                        'ParameterValue': rule_description,
                     },
                     {
                         'ParameterKey': 'SourceEvents',
@@ -1167,6 +1171,10 @@ class rdk:
                 print ("Existing IAM Role provided: " + self.args.lambda_role_arn)
                 lambdaRoleArn = self.args.lambda_role_arn
 
+            try:
+                rule_description = rule_params["Description"]
+            except KeyError:
+                rule_description = rule_name
             my_params = [
                 {
                     'ParameterKey': 'RuleName',
@@ -1174,7 +1182,7 @@ class rdk:
                 },
                 {
                     'ParameterKey': 'Description',
-                    'ParameterValue': rule_params["Description"],
+                    'ParameterValue': rule_description,
                 },
                 {
                     'ParameterKey': 'LambdaRoleArn',
@@ -1788,7 +1796,10 @@ class rdk:
             source["SourceDetails"] = []
 
             properties["ConfigRuleName"] = rule_name
-            properties["Description"] = params["Description"]
+            try:
+                properties["Description"] = params["Description"]
+            except KeyError:
+                properties["Description"] = rule_name
 
             #Create the SourceDetails stanza.
             if 'SourceEvents' in params:

--- a/rdk/template/configManagedRule.json
+++ b/rdk/template/configManagedRule.json
@@ -9,6 +9,12 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
     "SourceEvents": {
       "Description": "Event Type",
       "Type": "CommaDelimitedList",
@@ -42,7 +48,7 @@
       "Type": "AWS::Config::ConfigRule",
       "Properties": {
         "ConfigRuleName": { "Ref": "RuleName" },
-        "Description": { "Ref": "RuleName" },
+        "Description": { "Ref": "Description" },
         "Scope": {
           "Fn::If": [ "EventTriggered",
             { "ComplianceResourceTypes": { "Ref": "SourceEvents" } },

--- a/rdk/template/configManagedRuleWithRemediation.json
+++ b/rdk/template/configManagedRuleWithRemediation.json
@@ -8,6 +8,12 @@
             "MinLength": "1",
             "MaxLength": "255"
         },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
         "SourceEvents": {
             "Description": "Event Type",
             "Type": "CommaDelimitedList",
@@ -71,7 +77,7 @@
                     "Ref": "RuleName"
                 },
                 "Description": {
-                    "Ref": "RuleName"
+                    "Ref": "Description"
                 },
                 "Scope": {
                     "Fn::If": [

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -9,6 +9,12 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
     "LambdaRoleArn": {
       "Description": "ARN of the existing IAM role that you want to attach to the lambda function.",
       "Type": "String",
@@ -136,7 +142,7 @@
       ],
       "Properties": {
         "ConfigRuleName": { "Ref": "RuleName" },
-        "Description": { "Ref": "RuleName" },
+        "Description": { "Ref": "Description" },
         "Scope": {
           "Fn::If": [ "EventTriggered",
             { "ComplianceResourceTypes": { "Ref": "SourceEvents" } },


### PR DESCRIPTION
*Issue  https://github.com/awslabs/aws-config-rdk/issues/96*

*Description of changes:*
* Add "Description" parameter to the cloudformation templates.
* Add "Description" parameter into **parameters.json**
* Use the new "Description" parameter from **parameters.json** in the cloudformation template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
