### PR TITLE
RELEASE 0.7.10

### DIFF
--- a/docs/reference/deploy.rst
+++ b/docs/reference/deploy.rst
@@ -18,5 +18,6 @@ Deploy
    The ``--lambda-subnets`` flag can be used for attaching a comma-separated list of Subnets to deploy your Lambda function(s).
    The ``--lambda-security-groups`` flag can be used for attaching a comma-separated list of Security Groups to deploy with your Lambda function(s).
    The ``--custom-code-bucket`` flag can be used for providing the custom code S3 bucket name, which is not created with rdk init, for generated cloudformation template storage.
+   The ``--boundary-policy-arn`` flag can be used for attaching boundary Policy ARN that will be added to rdkLambdaRole.
 
    Note: Behind the scenes the ``--functions-only`` flag generates a CloudFormation template and runs a "create" or "update" on the targeted AWS Account and Region.  If subsequent calls to ``deploy`` with the ``--functions-only`` flag are made with the same stack name (either the default or otherwise) but with *different Config rules targeted*, any Rules deployed in previous ``deploy``s but not included in the latest ``deploy`` will be removed.  After a functions-only ``deploy`` _only_ the Rules specifically targeted by that command (either through Rulesets or an explicit list supplied on the command line) will be deployed in the environment, all others will be removed.s

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,5 +6,5 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.7.7"
+MY_VERSION = "0.7.8"
 

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,5 +6,5 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.7.9"
+MY_VERSION = "0.7.10"
 

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,5 +6,5 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.7.8"
+MY_VERSION = "0.7.9"
 

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1175,6 +1175,8 @@ class rdk:
             if self.args.boundary_policy_arn:
                 print ("Boundary Policy provided: " + self.args.boundary_policy_arn)
                 boundaryPolicyArn = self.args.boundary_policy_arn
+            else:
+                boundaryPolicyArn = ""
 
             try:
                 rule_description = rule_params["Description"]

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -989,10 +989,18 @@ class rdk:
                 print("Found Managed Rule.")
                 #create CFN Parameters for Managed Rules
 
+                try:
+                    rule_description = rule_params["Description"]
+                except KeyError:
+                    rule_description = rule_name
                 my_params = [
                     {
                         'ParameterKey': 'RuleName',
                         'ParameterValue': rule_name,
+                    },
+                    {
+                        'ParameterKey': 'Description',
+                        'ParameterValue': rule_description,
                     },
                     {
                         'ParameterKey': 'SourceEvents',
@@ -1163,10 +1171,18 @@ class rdk:
                 print ("Existing IAM Role provided: " + self.args.lambda_role_arn)
                 lambdaRoleArn = self.args.lambda_role_arn
 
+            try:
+                rule_description = rule_params["Description"]
+            except KeyError:
+                rule_description = rule_name
             my_params = [
                 {
                     'ParameterKey': 'RuleName',
                     'ParameterValue': rule_name,
+                },
+                {
+                    'ParameterKey': 'Description',
+                    'ParameterValue': rule_description,
                 },
                 {
                     'ParameterKey': 'LambdaRoleArn',
@@ -1780,7 +1796,10 @@ class rdk:
             source["SourceDetails"] = []
 
             properties["ConfigRuleName"] = rule_name
-            properties["Description"] = rule_name
+            try:
+                properties["Description"] = params["Description"]
+            except KeyError:
+                properties["Description"] = rule_name
 
             #Create the SourceDetails stanza.
             if 'SourceEvents' in params:
@@ -2423,6 +2442,7 @@ class rdk:
         #create config file and place in rule directory
         parameters = {
             'RuleName': self.args.rulename,
+            'Description': self.args.rulename,
             'SourceRuntime': self.args.runtime,
             #'CodeBucket': code_bucket_prefix + account_id,
             'CodeKey': self.args.rulename+'.zip',

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -475,7 +475,7 @@ class rdk:
             if self.args.skip_code_bucket_creation:
                 print('Skipping Code Bucket creation due to command line args')
             else:
-            print('Creating Code bucket '+code_bucket_name )
+                print('Creating Code bucket '+code_bucket_name )
 
             #Consideration for us-east-1 S3 API
             if my_session.region_name == 'us-east-1':

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1866,13 +1866,9 @@ class rdk:
                         resources[self.__get_alphanumeric_rule_name(rule_name+'Policy')] = ssm_iam_policy
                         remediation['Properties']['Parameters']['AutomationAssumeRole']['StaticValue']['Values'] = [{"Fn::GetAtt":[self.__get_alphanumeric_rule_name(rule_name+"Role"), "Arn"]}]
                         #Override the placeholder to associate the SSM Document Role with newly crafted role
-
- 
-
+                        resources[self.__get_alphanumeric_rule_name(rule_name+"RemediationAction")] = ssm_automation
                 resources[self.__get_alphanumeric_rule_name(rule_name)+"Remediation"] = remediation
-                resources[self.__get_alphanumeric_rule_name(rule_name+"RemediationAction")] = ssm_automation
-
-
+                
             if tags:
                 tags_str=""
                 for tag in tags:

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -243,6 +243,7 @@ def get_deployment_parser(ForceArgument=False, Command="deploy"):
     parser.add_argument('--lambda-layers', required=False, help="[optional] Comma-separated list of Lambda Layer ARNs to deploy with your Lambda function(s).")
     parser.add_argument('--lambda-subnets', required=False, help="[optional] Comma-separated list of Subnets to deploy your Lambda function(s).")
     parser.add_argument('--lambda-security-groups', required=False, help="[optional] Comma-separated list of Security Groups to deploy with your Lambda function(s).")
+    parser.add_argument('--boundary-policy-arn', required=False, help="[optional] Boundary Policy ARN that will be added to \"rdkLambdaRole\".")
 
     if ForceArgument:
         parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
@@ -1171,10 +1172,15 @@ class rdk:
                 print ("Existing IAM Role provided: " + self.args.lambda_role_arn)
                 lambdaRoleArn = self.args.lambda_role_arn
 
+            if self.args.boundary_policy_arn:
+                print ("Boundary Policy provided: " + self.args.boundary_policy_arn)
+                boundaryPolicyArn = self.args.boundary_policy_arn
+
             try:
                 rule_description = rule_params["Description"]
             except KeyError:
                 rule_description = rule_name
+                
             my_params = [
                 {
                     'ParameterKey': 'RuleName',
@@ -1187,6 +1193,10 @@ class rdk:
                 {
                     'ParameterKey': 'LambdaRoleArn',
                     'ParameterValue': lambdaRoleArn,
+                },
+                {
+                    'ParameterKey': 'BoundaryPolicyArn',
+                    'ParameterValue': boundaryPolicyArn,
                 },
                 {
                     'ParameterKey': 'SourceBucket',

--- a/rdk/template/configManagedRule.json
+++ b/rdk/template/configManagedRule.json
@@ -9,6 +9,12 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
     "SourceEvents": {
       "Description": "Event Type",
       "Type": "CommaDelimitedList",
@@ -42,7 +48,7 @@
       "Type": "AWS::Config::ConfigRule",
       "Properties": {
         "ConfigRuleName": { "Ref": "RuleName" },
-        "Description": { "Ref": "RuleName" },
+        "Description": { "Ref": "Description" },
         "Scope": {
           "Fn::If": [ "EventTriggered",
             { "ComplianceResourceTypes": { "Ref": "SourceEvents" } },

--- a/rdk/template/configManagedRuleWithRemediation.json
+++ b/rdk/template/configManagedRuleWithRemediation.json
@@ -8,6 +8,12 @@
             "MinLength": "1",
             "MaxLength": "255"
         },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
         "SourceEvents": {
             "Description": "Event Type",
             "Type": "CommaDelimitedList",
@@ -71,7 +77,7 @@
                     "Ref": "RuleName"
                 },
                 "Description": {
-                    "Ref": "RuleName"
+                    "Ref": "Description"
                 },
                 "Scope": {
                     "Fn::If": [

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -20,6 +20,11 @@
       "Type": "String",
       "Default": ""
     },
+    "BoundaryPolicyArn": {
+      "Description": "ARN of a Boundary Policy, will be used only if LambdaRoleArn is NOT set.",
+      "Type": "String",
+      "Default": ""
+    },
     "SourceBucket": {
       "Description": "Name of the S3 bucket that you have stored the rule zip files in.",
       "Type": "String",
@@ -77,6 +82,7 @@
   },
   "Conditions": {
     "CreateNewLambdaRole" : { "Fn::Equals" : [{ "Ref": "LambdaRoleArn" }, ""]},
+    "UseBoundaryPolicyInRole" : {"Fn::Not":[{ "Fn::Equals" : [{ "Ref": "BoundaryPolicyArn" }, ""]}]},
     "EventTriggered" : {"Fn::Not": [{ "Fn::Equals" : [{"Fn::Join": [",", { "Ref": "SourceEvents" }]}, "NONE"]}]},
     "PeriodicTriggered" : { "Fn::Not": [{"Fn::Equals" : [{ "Ref": "SourcePeriodic" }, "NONE"]}]},
     "UseAdditionalLayers": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Layers"}, ""]}]},
@@ -178,6 +184,11 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "Path": "/rdk/",
+        "PermissionsBoundary": {"Fn::If": [ "UseBoundaryPolicyInRole",
+            { "Ref": "BoundaryPolicyArn" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [ {

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -9,6 +9,12 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "Description": {
+      "Description": "Description of the Rule",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
     "LambdaRoleArn": {
       "Description": "ARN of the existing IAM role that you want to attach to the lambda function.",
       "Type": "String",
@@ -136,7 +142,7 @@
       ],
       "Properties": {
         "ConfigRuleName": { "Ref": "RuleName" },
-        "Description": { "Ref": "RuleName" },
+        "Description": { "Ref": "Description" },
         "Scope": {
           "Fn::If": [ "EventTriggered",
             { "ComplianceResourceTypes": { "Ref": "SourceEvents" } },


### PR DESCRIPTION

*Description of changes:*
1. Allow deployers to specify a --boundary-policy-arn, which gets injected into the generated AWS::IAM::Role, as PermissionsBoundary. (https://github.com/awslabs/aws-config-rdk/issues/264)
2. Add rule description into rule parameters (https://github.com/awslabs/aws-config-rdk/pull/266)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
