### PR TITLE
Adding 'SourceHandler' parameter

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2574,6 +2574,8 @@ class rdk:
                     time.sleep(5)
 
     def __get_handler(self, rule_name, params):
+        if 'SourceHandler' in params:
+            return params['SourceHandler']
         if params['SourceRuntime'] in ['python2.7', 'python3.6', 'python3.6-lib', 'python3.7', 'python3.8', 'nodejs4.3', 'nodejs6.10', 'nodejs8.10']:
             return (rule_name+'.lambda_handler')
         elif params['SourceRuntime'] in ['java8']:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change will allow you to manually set the value of `SourceHandler` which is used for the Lambda Function `Handler` property.

My use-case for this is a naming convention where hyphens are used in the Config rule names, but Python not liking hyphens in file names. Without this change, you are forced to use underscores instead of hyphens. With this change, you are free to name your rule whatever you want, and override the auto-generated value of `SourceHandler`.

This change is 100% backwards compatible and will not break any existing behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
