### PR TITLE
Put template files under MIT-0 license and remove license headers

### DIFF
--- a/rdk/template/LICENSE
+++ b/rdk/template/LICENSE
@@ -1,0 +1,14 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore1.0/CustomConfigHandler.cs
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore1.0/CustomConfigHandler.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore1.0/RuleCode.cs
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore1.0/RuleCode.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore2.0/CustomConfigHandler.cs
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore2.0/CustomConfigHandler.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore2.0/RuleCode.cs
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/dotnetcore2.0/RuleCode.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/java8/src/main/java/com/rdk/RuleCode.java
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/java8/src/main/java/com/rdk/RuleCode.java
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 package com.rdk;
 
 import java.io.IOException;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/java8/src/main/java/com/rdk/RuleUtil.java
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/java8/src/main/java/com/rdk/RuleUtil.java
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 package com.rdk;
 
 import java.io.IOException;

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/nodejs4.3/rule_code.js
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/nodejs4.3/rule_code.js
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 // RULE DESCRIPTION
 /// This example rule checks that EC2 instances are of the desired instance type
 // The desired instance type is specified in the rule parameters.

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/nodejs4.3/rule_util.js
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/nodejs4.3/rule_util.js
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 'use strict';
 
 const aws = require('aws-sdk');

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python2.7/rule_code.py
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python2.7/rule_code.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 from rule_util import *
 

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python2.7/rule_util.py
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python2.7/rule_util.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 import boto3
 import datetime

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python3.6/rule_code.py
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python3.6/rule_code.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 from rule_util import *
 

--- a/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python3.6/rule_util.py
+++ b/rdk/template/runtime/dotnetcore1.0/.rdk/runtime/python3.6/rule_util.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 import boto3
 import datetime

--- a/rdk/template/runtime/dotnetcore1.0/CustomConfigHandler.cs
+++ b/rdk/template/runtime/dotnetcore1.0/CustomConfigHandler.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/rdk/template/runtime/dotnetcore1.0/RuleCode.cs
+++ b/rdk/template/runtime/dotnetcore1.0/RuleCode.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/rdk/template/runtime/dotnetcore2.0/CustomConfigHandler.cs
+++ b/rdk/template/runtime/dotnetcore2.0/CustomConfigHandler.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/rdk/template/runtime/dotnetcore2.0/RuleCode.cs
+++ b/rdk/template/runtime/dotnetcore2.0/RuleCode.cs
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/rdk/template/runtime/java8/src/main/java/com/rdk/RuleCode.java
+++ b/rdk/template/runtime/java8/src/main/java/com/rdk/RuleCode.java
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 package com.rdk;
 
 import java.io.IOException;

--- a/rdk/template/runtime/java8/src/main/java/com/rdk/RuleUtil.java
+++ b/rdk/template/runtime/java8/src/main/java/com/rdk/RuleUtil.java
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 package com.rdk;
 
 import java.io.IOException;

--- a/rdk/template/runtime/nodejs4.3/rule_code.js
+++ b/rdk/template/runtime/nodejs4.3/rule_code.js
@@ -1,13 +1,3 @@
-/*
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-*/
-
 'use strict';
 
 const aws = require('aws-sdk');

--- a/rdk/template/runtime/python2.7/rule_code.py
+++ b/rdk/template/runtime/python2.7/rule_code.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 import boto3
 import botocore

--- a/rdk/template/runtime/python3.6-lib/rule_code.py
+++ b/rdk/template/runtime/python3.6-lib/rule_code.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType
 <%ApplicableResources1%>
 class <%RuleName%>(ConfigRule):

--- a/rdk/template/runtime/python3.6-lib/rule_test.py
+++ b/rdk/template/runtime/python3.6-lib/rule_test.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import unittest
 from mock import patch, MagicMock
 from botocore.exceptions import ClientError

--- a/rdk/template/runtime/python3.6-managed/managed-rule-code/rule_code.py
+++ b/rdk/template/runtime/python3.6-managed/managed-rule-code/rule_code.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 import datetime
 

--- a/rdk/template/runtime/python3.6-managed/managed-rule-code/rule_util.py
+++ b/rdk/template/runtime/python3.6-managed/managed-rule-code/rule_util.py
@@ -1,11 +1,3 @@
-#    Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-#    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 import json
 import boto3
 import datetime

--- a/rdk/template/runtime/python3.6/rule_code.py
+++ b/rdk/template/runtime/python3.6/rule_code.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import json
 import sys
 import datetime

--- a/rdk/template/runtime/python3.6/rule_test.py
+++ b/rdk/template/runtime/python3.6/rule_test.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import sys
 import unittest
 try:

--- a/rdk/template/runtime/python3.7/rule_code.py
+++ b/rdk/template/runtime/python3.7/rule_code.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import json
 import sys
 import datetime

--- a/rdk/template/runtime/python3.7/rule_test.py
+++ b/rdk/template/runtime/python3.7/rule_test.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import sys
 import unittest
 try:

--- a/rdk/template/runtime/python3.8/rule_code.py
+++ b/rdk/template/runtime/python3.8/rule_code.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import json
 import sys
 import datetime

--- a/rdk/template/runtime/python3.8/rule_test.py
+++ b/rdk/template/runtime/python3.8/rule_test.py
@@ -1,14 +1,3 @@
-# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may
-# not use this file except in compliance with the License. A copy of the License is located at
-#
-#        http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-# the specific language governing permissions and limitations under the License.
-
 import sys
 import unittest
 try:


### PR DESCRIPTION
*Description of changes:*
Because template files are copied into customer code repositories, we want to grant a license that has no conditions for the customer to fulfill. There's then also no great need to have Amazon copyright headers in these files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
