### PR TITLE
Update README for Cross Account additional arguments.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,16 @@ To use the RDK, it's recommended to create a directory that will be your working
 
 Running ``init`` subsequent times will validate your AWS Config setup and re-create any S3 buckets or IAM resources that are needed.
 
+- If you have config delievery bucket already present in some other AWS account then use **--config-bucket-exists-in-another-account** as argument:::
+
+  $ rdk init --config-bucket-exists-in-another-account
+- If you have AWS Organizations/ControlTower Setup in your AWS environment then additionally, use **--control-tower** as argument:::
+
+  $ rdk init --control-tower --config-bucket-exists-in-another-account
+- If bucket for custom lambda code is already present in current account then use **--skip-code-bucket-creation** argument:::
+
+  $ rdk init --skip-code-bucket-creation
+
 Create Rules
 ------------
 In your working directory, use the ``create`` command to start creating a new custom rule.  You must specify the runtime for the lambda function that will back the Rule, and you can also specify a resource type (or comma-separated list of types) that the Rule will evaluate or a maximum frequency for a periodic rule.  This will add a new directory for the rule and populate it with several files, including a skeleton of your Lambda code.


### PR DESCRIPTION
**Issue #, if available:**

none

**Description of changes:**

In the root **README** of this repo, `rdk init` command is a bit ambiguous for **multi-account/control-tower** users as it doesn't provide full information at first look. You have to dig in the previous issues/PRs to find the fact that additional arguments have to be provided for config-rdk installation which is only a waste of time.
So, I have just added those additional arguments in the readme to avoid the caused hassle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
