### PR TITLE
Update Python 3 runtime templates to use unittest.mock

### DIFF
--- a/rdk/template/runtime/python3.6-lib/rule_test.py
+++ b/rdk/template/runtime/python3.6-lib/rule_test.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from botocore.exceptions import ClientError
 import rdklib
 from rdklib import Evaluation, ComplianceType

--- a/rdk/template/runtime/python3.6/rule_test.py
+++ b/rdk/template/runtime/python3.6/rule_test.py
@@ -1,9 +1,6 @@
 import sys
 import unittest
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 import botocore
 
 ##############

--- a/rdk/template/runtime/python3.7/rule_test.py
+++ b/rdk/template/runtime/python3.7/rule_test.py
@@ -1,9 +1,6 @@
 import sys
 import unittest
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 import botocore
 
 ##############

--- a/rdk/template/runtime/python3.8/rule_test.py
+++ b/rdk/template/runtime/python3.8/rule_test.py
@@ -1,9 +1,6 @@
 import sys
 import unittest
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 import botocore
 
 ##############


### PR DESCRIPTION
*Description of changes:*
The unittest package has included mock since Python 3.3. These changes update the Python 3.6, 3.6-lib, 3.7, and 3.8 templates to default to unittest.mock instead of trying to import mock.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
