### PR TITLE
Changed 'RDK-Rule-Function-' to 'RDK-' as this saves up 14 characters

### DIFF
--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -102,14 +102,14 @@
     "rdkRuleCodeLambda": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
-        "FunctionName": { "Fn::Join" : [ "", [ "RDK-Rule-Function-", { "Ref": "RuleName" }]]},
+        "FunctionName": { "Fn::Join" : [ "", [ "RDK-", { "Ref": "RuleName" }]]},
         "Code": {
           "S3Bucket": { "Ref": "SourceBucket" },
           "S3Key": { "Fn::Join" : [ "", [ { "Ref": "RuleName" }, "/", { "Ref": "RuleName" }, ".zip"]]}
         },
         "Description": "Create a new AWS lambda function for rule code",
         "Handler": { "Ref": "SourceHandler"},
-        "MemorySize": "256",
+        "MemorySize": 256,
         "Role": {
           "Fn::If": [ "CreateNewLambdaRole",
               { "Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]},


### PR DESCRIPTION
… for writing the RULE_NAME

*Issue #, if available:*

*Description of changes:*
Changed the Cloud Formation ConfigRule.json creating Lambda Function to use 'RDK-' instead of 'RDK-Rule-Function-'. By doing this it save up more 14 characters for the RULE_NAME

Also changed the value type for attribute memory size from string to an integer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
