### PR TITLE
Updated the Lambda Function name isndie CloudFormation template to use a shorter prefix

### DIFF
--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -102,7 +102,7 @@
     "rdkRuleCodeLambda": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
-        "FunctionName": { "Fn::Join" : [ "", [ "RDK-Rule-Function-", { "Ref": "RuleName" }]]},
+        "FunctionName": { "Fn::Join" : [ "", [ "RDK-", { "Ref": "RuleName" }]]},
         "Code": {
           "S3Bucket": { "Ref": "SourceBucket" },
           "S3Key": { "Fn::Join" : [ "", [ { "Ref": "RuleName" }, "/", { "Ref": "RuleName" }, ".zip"]]}

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -109,7 +109,7 @@
         },
         "Description": "Create a new AWS lambda function for rule code",
         "Handler": { "Ref": "SourceHandler"},
-        "MemorySize": "256",
+        "MemorySize": 256,
         "Role": {
           "Fn::If": [ "CreateNewLambdaRole",
               { "Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1] Updating the Cloud Formation template "ConfigRule.json" creating Lambda resource to use prefix 'RDK-' instead of 'RDK-Rule-Function-' for naming the Lambda Function. By doing this it saves up more 14 characters for naming the config rule

2] Updated the value type for attribute memory size from string to an integer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
