### PR TITLE
Adding new optional parameter [--custom-lambda-prefix]

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2353,6 +2353,13 @@ class rdk:
         if is_required and not self.args.resource_types and not self.args.maximum_frequency:
             print("You must specify either a resource type trigger or a maximum frequency.")
             sys.exit(1)
+            
+        if self.args.input_parameters:
+            try:
+                input_params_dict = json.loads(self.args.input_parameters, strict=False)
+            except Exception as e:
+                print("Failed to parse input parameters.")
+                sys.exit(1)
 
         if is_required and self.args.shorter_lambda_prefix:
             if self.args.shorter_lambda_prefix != "yes":

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -2356,7 +2356,7 @@ class rdk:
 
         if is_required and self.args.shorter_lambda_prefix:
             if self.args.shorter_lambda_prefix != "yes":
-                print("Error: Only 'yes' is supported as an argument")
+                print("Error: Only 'yes' is supported as an argument for --shorter-lambda-prefix")
                 sys.exit(1)
 
         if self.args.optional_parameters:

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1667,11 +1667,6 @@ class rdk:
 
         self.args.rulename = self.__clean_rule_name(self.args.rulename)
 
-        if self.args.custom_lambda_prefix:
-            if self.args.custom_lambda_prefix is None:
-                print("Error: Custom Lambda Prefix needs to be assigned with a non empty string value")
-                sys.exit(1)
-
         my_session = self.__get_boto_session()
         cw_logs = my_session.client('logs')
         log_group_name = self.__get_log_group_name()
@@ -1771,11 +1766,6 @@ class rdk:
 
         if self.args.rulesets:
             self.args.rulesets = self.args.rulesets.split(',')
-
-        if self.args.custom_lambda_prefix:
-            if self.args.custom_lambda_prefix is None:
-                print("Error: Custom Lambda Prefix needs to be assigned with a non empty string value")
-                sys.exit(1)
 
         script_for_tag=""
 
@@ -2378,11 +2368,6 @@ class rdk:
                 print("Failed to parse input parameters.")
                 sys.exit(1)
 
-        if is_required and self.args.custom_lambda_prefix:
-            if self.args.custom_lambda_prefix is None:
-                print("Error: Custom Lambda Prefix needs to be assigned with a non empty string value")
-                sys.exit(1)
-
         if self.args.optional_parameters:
             try:
                 optional_params_dict = json.loads(self.args.optional_parameters, strict=False)
@@ -2435,11 +2420,6 @@ class rdk:
                 if len(name) > 128:
                     print("Error: Found Rule with name over 128 characters: {} \n Recreate the Rule with a shorter name.".format(name))
                     sys.exit(1)
-        
-        if self.args.custom_lambda_prefix:
-            if self.args.custom_lambda_prefix is None:
-                print("Error: Custom Lambda Prefix needs to be assigned with a non empty string value")
-                sys.exit(1)
 
         if self.args.functions_only and not self.args.stack_name:
             self.args.stack_name = "RDK-Config-Rule-Functions"

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -282,7 +282,7 @@ def get_rule_parser(is_required, command):
     parser.add_argument('--remediation-error-rate-percent', required=False, help='[optional] Error rate that will mark the batch as "failed" for SSM remediation execution.')
     parser.add_argument('--remediation-parameters', required=False, help='[optional] JSON-formatted string of additional parameters required by the SSM document.')
     parser.add_argument('--automation-document', required=False, help='[optional, beta] JSON-formatted string of the SSM Automation Document.')
-    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
+    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Pass "yes" as an argument to use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
 
     return parser
 
@@ -314,6 +314,7 @@ def get_deployment_parser(ForceArgument=False, Command="deploy"):
     parser.add_argument('--lambda-security-groups', required=False, help="[optional] Comma-separated list of Security Groups to deploy with your Lambda function(s).")
     parser.add_argument('--lambda-timeout', required=False, default=60, help="[optional] Timeout (in seconds) for the lambda function", type=str)
     parser.add_argument('--boundary-policy-arn', required=False, help="[optional] Boundary Policy ARN that will be added to \"rdkLambdaRole\".")
+    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Pass "yes" as an argument to use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
 
     if ForceArgument:
         parser.add_argument("--force", required=False, action='store_true', help='[optional] Remove selected Rules from account without prompting for confirmation.')
@@ -374,6 +375,7 @@ def get_logs_parser():
     parser.add_argument('rulename', metavar='<rulename>', help='Rule whose logs will be displayed')
     parser.add_argument('-f','--follow',  action='store_true', help='[optional] Continuously poll Lambda logs and write to stdout.')
     parser.add_argument('-n','--number',  default=3, help='[optional] Number of previous logged events to display.')
+    parser.add_argument('-s','--shorter-lambda-prefix', required=False, help='[optional] Pass "yes" as an argument if you opted to use prefix "RDK-" instead of "RDK-Rule-Function-" for naming the lambda function')
     return parser
 
 def get_rulesets_parser():
@@ -399,6 +401,7 @@ def get_create_rule_template_parser():
     parser.add_argument('-t','--tag-config-rules-script', required=False, help="filename of generated script to tag config rules with the tags in each paramter.json")
     parser.add_argument('--config-role-arn', required=False, help="[optional] Assign existing iam role as config role. If omitted, \"config-role\" will be created.")
     parser.add_argument('--rules-only', action="store_true", help="[optional] Generate a CloudFormation Template that only includes the Config Rules and not the Bucket, Configuration Recorder, and Delivery Channel.")
+    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
     return parser
 
 class rdk:
@@ -1941,8 +1944,10 @@ class rdk:
                 del source["SourceDetails"]
             else:
                 source["Owner"] = "CUSTOM_LAMBDA"
+                if self.args.shorter_lambda_prefix:
+                    source["SourceIdentifier"] = { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${LambdaAccountId}:function:RDK-"+self.__get_stack_name_from_rule_name(rule_name) }
                 source["SourceIdentifier"] = { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${LambdaAccountId}:function:RDK-Rule-Function-"+self.__get_stack_name_from_rule_name(rule_name) }
-
+            
             properties["Source"] = source
 
             properties["InputParameters"] = {}
@@ -2205,6 +2210,8 @@ class rdk:
         return log_events
 
     def __get_log_group_name(self):
+        if self.args.shorter_lambda_prefix:
+            return '/aws/lambda/RDK-' + self.args.rulename
         return '/aws/lambda/RDK-Rule-Function-' + self.args.rulename
 
     def __get_boto_session(self):
@@ -2418,6 +2425,11 @@ class rdk:
                 if len(name) > 128:
                     print("Error: Found Rule with name over 128 characters: {} \n Recreate the Rule with a shorter name.".format(name))
                     sys.exit(1)
+        
+        if self.args.shorter_lambda_prefix:
+            if self.args.shorter_lambda_prefix != "yes":
+                print("Error: Only 'yes' is supported as an argument for --shorter-lambda-prefix")
+                sys.exit(1)
 
         if self.args.functions_only and not self.args.stack_name:
             self.args.stack_name = "RDK-Config-Rule-Functions"
@@ -2743,6 +2755,8 @@ class rdk:
         return my_lambda_arn
 
     def __get_lambda_arn_for_rule(self, rule_name, partition, region, account):
+        if self.args.shorter_lambda_prefix:
+            return "arn:{}:lambda:{}:{}:function:RDK-{}".format(partition, region, account, self.__get_stack_name_from_rule_name(rule_name))
         return "arn:{}:lambda:{}:{}:function:RDK-Rule-Function-{}".format(partition, region, account, self.__get_stack_name_from_rule_name(rule_name))
 
     def __delete_package_file(self, file):
@@ -3014,7 +3028,10 @@ class rdk:
             lambda_function = {}
             lambda_function["Type"] = "AWS::Lambda::Function"
             properties = {}
-            properties["FunctionName"] = "RDK-Rule-Function-" + stack_name
+            if self.args.shorter_lambda_prefix:
+                properties["FunctionName"] = "RDK-" + stack_name
+            else:
+                properties["FunctionName"] = "RDK-Rule-Function-" + stack_name
             properties["Code"] = {"S3Bucket": { "Ref": "SourceBucket"}, "S3Key": rule_name+"/"+rule_name+".zip"}
             properties["Description"] = "Function for AWS Config Rule " + rule_name
             properties["Handler"] = self.__get_handler(rule_name, params)

--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -401,7 +401,7 @@ def get_create_rule_template_parser():
     parser.add_argument('-t','--tag-config-rules-script', required=False, help="filename of generated script to tag config rules with the tags in each paramter.json")
     parser.add_argument('--config-role-arn', required=False, help="[optional] Assign existing iam role as config role. If omitted, \"config-role\" will be created.")
     parser.add_argument('--rules-only', action="store_true", help="[optional] Generate a CloudFormation Template that only includes the Config Rules and not the Bucket, Configuration Recorder, and Delivery Channel.")
-    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
+    parser.add_argument('--shorter-lambda-prefix', required=False, help='[optional] Pass "yes" as an argument to use a shorter prefix for naming the lambda function. "RDK-" instead of "RDK-Rule-Function-"')
     return parser
 
 class rdk:

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -102,7 +102,7 @@
     "rdkRuleCodeLambda": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
-        "FunctionName": { "Fn::Join" : [ "", [ "RDK-Rule-Function-", { "Ref": "RuleName" }]]},
+        "FunctionName": { "Fn::Join" : [ "", [ "RDK-", { "Ref": "RuleName" }]]},
         "Code": {
           "S3Bucket": { "Ref": "SourceBucket" },
           "S3Key": { "Fn::Join" : [ "", [ { "Ref": "RuleName" }, "/", { "Ref": "RuleName" }, ".zip"]]}

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -7,13 +7,13 @@
       "Description": "Name of the Rule",
       "Type": "String",
       "MinLength": "1",
-      "MaxLength": "255"
+      "MaxLength": "128"
     },
     "LambdaFunctionName":{
       "Description": "Name of the Lambda Function",
       "Type": "String",
       "MinLength": "1",
-      "MaxLength": "255"
+      "MaxLength": "64"
     },
     "Description": {
       "Description": "Description of the Rule",
@@ -111,7 +111,7 @@
         "FunctionName": { "Ref": "LambdaFunctionName"},
         "Code": {
           "S3Bucket": { "Ref": "SourceBucket" },
-          "S3Key": { "Fn::Join" : [ "", [ { "Ref": "RuleName" }, "/", { "Ref": "RuleName" }, ".zip"]]}
+          "S3Key": { "Ref": "SourcePath" }
         },
         "Description": "Create a new AWS lambda function for rule code",
         "Handler": { "Ref": "SourceHandler"},

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -109,7 +109,7 @@
         },
         "Description": "Create a new AWS lambda function for rule code",
         "Handler": { "Ref": "SourceHandler"},
-        "MemorySize": "256",
+        "MemorySize": 256,
         "Role": {
           "Fn::If": [ "CreateNewLambdaRole",
               { "Fn::GetAtt": [ "rdkLambdaRole", "Arn" ]},

--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -9,6 +9,12 @@
       "MinLength": "1",
       "MaxLength": "255"
     },
+    "LambdaFunctionName":{
+      "Description": "Name of the Lambda Function",
+      "Type": "String",
+      "MinLength": "1",
+      "MaxLength": "255"
+    },
     "Description": {
       "Description": "Description of the Rule",
       "Type": "String",
@@ -102,7 +108,7 @@
     "rdkRuleCodeLambda": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
-        "FunctionName": { "Fn::Join" : [ "", [ "RDK-", { "Ref": "RuleName" }]]},
+        "FunctionName": { "Ref": "LambdaFunctionName"},
         "Code": {
           "S3Bucket": { "Ref": "SourceBucket" },
           "S3Key": { "Fn::Join" : [ "", [ { "Ref": "RuleName" }, "/", { "Ref": "RuleName" }, ".zip"]]}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding new optional parameter [--custom-lambda-prefix]

1] Its an optional parameter
2] Only accepts non empty string as argument
3] If --custom-lambda-prefix is used with argument then LambdaFunctionName : custom-prefix + RuleName
4] If --custom-lambda-prefix is used with no argument then LambdaFunctionName  : Error (once we used the flag, it needs to be assigned with a non empty str value)
5] If no --custom-lambda-prefix  provided, then default to : RDK-Rule-Function + RuleName 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
