### PR TITLE
Add support for Python 3.9 Lambda runtimes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,8 @@ include rdk/template/runtime/python3.7/*
 include rdk/template/runtime/python3.7-lib/*
 include rdk/template/runtime/python3.8/*
 include rdk/template/runtime/python3.8-lib/*
+include rdk/template/runtime/python3.9/*
+include rdk/template/runtime/python3.9-lib/*
 include rdk/template/runtime/dotnetcore1.0/*
 include rdk/template/runtime/dotnetcore1.0/bin/*
 include rdk/template/runtime/dotnetcore1.0/obj/*

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ For complete documentation, including command reference, check out the `ReadTheD
 
 Getting Started
 ===============
-Uses python 3.6/3.7/3.8 and is installed via pip.  Requires you to have an AWS account and sufficient permissions to manage the Config service, and to create S3 Buckets, Roles, and Lambda Functions.  An AWS IAM Policy Document that describes the minimum necessary permissions can be found at policy/rdk-minimum-permissions.json.
+Uses python 3.6/3.7/3.8/3.9 and is installed via pip.  Requires you to have an AWS account and sufficient permissions to manage the Config service, and to create S3 Buckets, Roles, and Lambda Functions.  An AWS IAM Policy Document that describes the minimum necessary permissions can be found at policy/rdk-minimum-permissions.json.
 
 Under the hood, rdk uses boto3 to make API calls to AWS, so you can set your credentials any way that boto3 recognizes (options 3 through 8 here: http://boto3.readthedocs.io/en/latest/guide/configuration.html) or pass them in with the command-line parameters --profile, --region, --access-key-id, or --secret-access-key
 
@@ -55,7 +55,7 @@ To use the RDK, it's recommended to create a directory that will be your working
 
 Running ``init`` subsequent times will validate your AWS Config setup and re-create any S3 buckets or IAM resources that are needed.
 
-- If you have config delievery bucket already present in some other AWS account then use **--config-bucket-exists-in-another-account** as argument:::
+- If you have config delivery bucket already present in some other AWS account then use **--config-bucket-exists-in-another-account** as argument:::
 
   $ rdk init --config-bucket-exists-in-another-account
 - If you have AWS Organizations/ControlTower Setup in your AWS environment then additionally, use **--control-tower** as argument:::
@@ -162,7 +162,7 @@ The exact output will vary depending on Lambda runtime.  You can use the --all f
 
 Deploy Organization Rule
 ------------------------
-You can also deploy the Rule to your AWS Orgnization using the ``deploy-organization`` command.
+You can also deploy the Rule to your AWS Organization using the ``deploy-organization`` command.
 For successful evaluation of custom rules in child accounts, please make sure you do one of the following: 
 
 1. Set ASSUME_ROLE_MODE in Lambda code to True, to get the lambda to assume the Role attached on the Config Service and confirm that the role trusts the master account where the Lambda function is going to be deployed.
@@ -204,7 +204,7 @@ You can use the ``-n`` and ``-f`` command line flags just like the UNIX ``tail``
 Running the tests
 =================
 
-The `testing` directory contains scripts and buildspec files that I use to run basic functionality tests across a variety of CLI environemnts (currently Ubuntu linux running python 3.6/3.7/3.8, and Windows Server running python3.6).  If there is interest I can release a CloudFormation template that could be used to build the test environment, let me know if this is something you want!
+The `testing` directory contains scripts and buildspec files that I use to run basic functionality tests across a variety of CLI environments (currently Ubuntu linux running python 3.6/3.7/3.8/3.9, and Windows Server running python3.6).  If there is interest I can release a CloudFormation template that could be used to build the test environment, let me know if this is something you want!
 
 
 Advanced Features
@@ -242,7 +242,7 @@ It is now possible to define a resource type that is not yet supported by rdk. T
   
 Custom Lambda Function Name
 ---------------------------
-As of version 0.7.14, instead of defaulting the lambda function names to 'RDK-Rule-Function-<RULE_NAME>' it is possible to customize the name for lambda function to any 64 characters string as per lambda naming standrds using the optional '--custom-lambda-name' flag while performing rdk create. This opens up new features like : 
+As of version 0.7.14, instead of defaulting the lambda function names to 'RDK-Rule-Function-<RULE_NAME>' it is possible to customize the name for the Lambda function to any 64 characters string as per Lambda's naming standards using the optional '--custom-lambda-name' flag while performing rdk create. This opens up new features like : 
 
 1. Longer config rule name.
 2. Custom lambda function naming as per personal or enterprise standards.

--- a/rdk/__init__.py
+++ b/rdk/__init__.py
@@ -6,4 +6,4 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-MY_VERSION = "0.8.1"
+MY_VERSION = "0.8.2"

--- a/rdk/template/runtime/python3.9-lib/rule_code.py
+++ b/rdk/template/runtime/python3.9-lib/rule_code.py
@@ -1,0 +1,25 @@
+from rdklib import Evaluator, Evaluation, ConfigRule, ComplianceType
+<%ApplicableResources1%>
+class <%RuleName%>(ConfigRule):
+    def evaluate_change(self, event, client_factory, configuration_item, valid_rule_parameters):
+        ###############################
+        # Add your custom logic here. #
+        ###############################
+
+        return [Evaluation(ComplianceType.NOT_APPLICABLE)]
+
+    #def evaluate_periodic(self, event, client_factory, valid_rule_parameters):
+    #    pass
+
+    def evaluate_parameters(self, rule_parameters):
+        valid_rule_parameters = rule_parameters
+        return valid_rule_parameters
+
+
+################################
+# DO NOT MODIFY ANYTHING BELOW #
+################################
+def lambda_handler(event, context):
+    my_rule = <%RuleName%>()
+    evaluator = Evaluator(my_rule<%ApplicableResources2%>)
+    return evaluator.handle(event, context)

--- a/rdk/template/runtime/python3.9-lib/rule_test.py
+++ b/rdk/template/runtime/python3.9-lib/rule_test.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError
+import rdklib
+from rdklib import Evaluation, ComplianceType
+import rdklibtest
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+RESOURCE_TYPE = 'AWS::::Account'
+
+#############
+# Main Code #
+#############
+
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
+
+CLIENT_FACTORY = MagicMock()
+
+#example for mocking S3 API calls
+S3_CLIENT_MOCK = MagicMock()
+
+def mock_get_client(client_name, *args, **kwargs):
+    if client_name == 's3':
+        return S3_CLIENT_MOCK
+    raise Exception("Attempting to create an unknown client")
+
+@patch.object(CLIENT_FACTORY, 'build_client', MagicMock(side_effect=mock_get_client))
+class ComplianceTest(unittest.TestCase):
+
+    rule_parameters = '{"SomeParameterKey":"SomeParameterValue","SomeParameterKey2":"SomeParameterValue2"}'
+
+    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"some-arn"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+
+    def setUp(self):
+        pass
+
+    def test_sample(self):
+        self.assertTrue(True)
+
+    #def test_sample_2(self):
+    #    response = MODULE.lambda_handler(rdklib.build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+    #    resp_expected = []
+    #    resp_expected.append(rdklib.build_expected_response('NOT_APPLICABLE', 'some-resource-id', 'AWS::IAM::Role'))
+    #    rdklib.assert_successful_evaluation(self, response, resp_expected)

--- a/rdk/template/runtime/python3.9/rule_code.py
+++ b/rdk/template/runtime/python3.9/rule_code.py
@@ -1,0 +1,388 @@
+import json
+import sys
+import datetime
+import boto3
+import botocore
+
+try:
+    import liblogging
+except ImportError:
+    pass
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::::Account'
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (useful for cross-account).
+ASSUME_ROLE_MODE = False
+
+# Other parameters (no change needed)
+CONFIG_ROLE_TIMEOUT_SECONDS = 900
+
+#############
+# Main Code #
+#############
+
+def evaluate_compliance(event, configuration_item, valid_rule_parameters):
+    """Form the evaluation(s) to be return to Config Rules
+
+    Return either:
+    None -- when no result needs to be displayed
+    a string -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    a dictionary -- the evaluation dictionary, usually built by build_evaluation_from_config_item()
+    a list of dictionary -- a list of evaluation dictionary , usually built by build_evaluation()
+
+    Keyword arguments:
+    event -- the event variable given in the lambda handler
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    valid_rule_parameters -- the output of the evaluate_parameters() representing validated parameters of the Config Rule
+
+    Advanced Notes:
+    1 -- if a resource is deleted and generate a configuration change with ResourceDeleted status, the Boilerplate code will put a NOT_APPLICABLE on this resource automatically.
+    2 -- if a None or a list of dictionary is returned, the old evaluation(s) which are not returned in the new evaluation list are returned as NOT_APPLICABLE by the Boilerplate code
+    3 -- if None or an empty string, list or dict is returned, the Boilerplate code will put a "shadow" evaluation to feedback that the evaluation took place properly
+    """
+
+    ###############################
+    # Add your custom logic here. #
+    ###############################
+
+    return 'NOT_APPLICABLE'
+
+def evaluate_parameters(rule_parameters):
+    """Evaluate the rule parameters dictionary validity. Raise a ValueError for invalid parameters.
+
+    Return:
+    anything suitable for the evaluate_compliance()
+
+    Keyword arguments:
+    rule_parameters -- the Key/Value dictionary of the Config Rules parameters
+    """
+    valid_rule_parameters = rule_parameters
+    return valid_rule_parameters
+
+####################
+# Helper Functions #
+####################
+
+# Build an error to be displayed in the logs when the parameter is invalid.
+def build_parameters_value_error_response(ex):
+    """Return an error dictionary when the evaluate_parameters() raises a ValueError.
+
+    Keyword arguments:
+    ex -- Exception text
+    """
+    return  build_error_response(internal_error_message="Parameter value is invalid",
+                                 internal_error_details="An ValueError was raised during the validation of the Parameter value",
+                                 customer_error_code="InvalidParameterValueException",
+                                 customer_error_message=str(ex))
+
+# This gets the client after assuming the Config service role
+# either in the same AWS account or cross-account.
+def get_client(service, event, region=None):
+    """Return the service boto client. It should be used instead of directly calling the client.
+
+    Keyword arguments:
+    service -- the service name used for calling the boto.client()
+    event -- the event variable given in the lambda handler
+    region -- the region where the client is called (default: None)
+    """
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service, region)
+    credentials = get_assume_role_credentials(get_execution_role_arn(event), region)
+    return boto3.client(service, aws_access_key_id=credentials['AccessKeyId'],
+                        aws_secret_access_key=credentials['SecretAccessKey'],
+                        aws_session_token=credentials['SessionToken'],
+                        region_name=region
+                       )
+
+# This generate an evaluation for config
+def build_evaluation(resource_id, compliance_type, event, resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on scheduled rules.
+
+    Keyword arguments:
+    resource_id -- the unique id of the resource to report
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    event -- the event variable given in the lambda handler
+    resource_type -- the CloudFormation resource type (or AWS::::Account) to report on the rule (default DEFAULT_RESOURCE_TYPE)
+    annotation -- an annotation to be added to the evaluation (default None). It will be truncated to 255 if longer.
+    """
+    eval_cc = {}
+    if annotation:
+        eval_cc['Annotation'] = build_annotation(annotation)
+    eval_cc['ComplianceResourceType'] = resource_type
+    eval_cc['ComplianceResourceId'] = resource_id
+    eval_cc['ComplianceType'] = compliance_type
+    eval_cc['OrderingTimestamp'] = str(json.loads(event['invokingEvent'])['notificationCreationTime'])
+    return eval_cc
+
+def build_evaluation_from_config_item(configuration_item, compliance_type, annotation=None):
+    """Form an evaluation as a dictionary. Usually suited to report on configuration change rules.
+
+    Keyword arguments:
+    configuration_item -- the configurationItem dictionary in the invokingEvent
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    annotation -- an annotation to be added to the evaluation (default None). It will be truncated to 255 if longer.
+    """
+    eval_ci = {}
+    if annotation:
+        eval_ci['Annotation'] = build_annotation(annotation)
+    eval_ci['ComplianceResourceType'] = configuration_item['resourceType']
+    eval_ci['ComplianceResourceId'] = configuration_item['resourceId']
+    eval_ci['ComplianceType'] = compliance_type
+    eval_ci['OrderingTimestamp'] = configuration_item['configurationItemCaptureTime']
+    return eval_ci
+
+####################
+# Boilerplate Code #
+####################
+
+# Get execution role for Lambda function
+def get_execution_role_arn(event):
+    role_arn = None
+    if 'ruleParameters' in event:
+        rule_params = json.loads(event['ruleParameters'])
+        role_name = rule_params.get("ExecutionRoleName")
+        if role_name:
+            execution_role_prefix = event["executionRoleArn"].split("/")[0]
+            role_arn = "{}/{}".format(execution_role_prefix, role_name)
+
+    if not role_arn:
+        role_arn = event['executionRoleArn']
+
+    return role_arn
+
+# Build annotation within Service constraints
+def build_annotation(annotation_string):
+    if len(annotation_string) > 256:
+        return annotation_string[:244] + " [truncated]"
+    return annotation_string
+
+# Helper function used to validate input
+def check_defined(reference, reference_name):
+    if not reference:
+        raise Exception('Error: ', reference_name, 'is not defined')
+    return reference
+
+# Check whether the message is OversizedConfigurationItemChangeNotification or not
+def is_oversized_changed_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'OversizedConfigurationItemChangeNotification'
+
+# Check whether the message is a ScheduledNotification or not.
+def is_scheduled_notification(message_type):
+    check_defined(message_type, 'messageType')
+    return message_type == 'ScheduledNotification'
+
+# Get configurationItem using getResourceConfigHistory API
+# in case of OversizedConfigurationItemChangeNotification
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1)
+    configuration_item = result['configurationItems'][0]
+    return convert_api_configuration(configuration_item)
+
+# Convert from the API model to the original invocation model
+def convert_api_configuration(configuration_item):
+    for k, v in configuration_item.items():
+        if isinstance(v, datetime.datetime):
+            configuration_item[k] = str(v)
+    configuration_item['awsAccountId'] = configuration_item['accountId']
+    configuration_item['ARN'] = configuration_item['arn']
+    configuration_item['configurationStateMd5Hash'] = configuration_item['configurationItemMD5Hash']
+    configuration_item['configurationItemVersion'] = configuration_item['version']
+    configuration_item['configuration'] = json.loads(configuration_item['configuration'])
+    if 'relationships' in configuration_item:
+        for i in range(len(configuration_item['relationships'])):
+            configuration_item['relationships'][i]['name'] = configuration_item['relationships'][i]['relationshipName']
+    return configuration_item
+
+# Based on the type of message get the configuration item
+# either from configurationItem in the invoking event
+# or using the getResourceConfigHistiry API in getConfiguration function.
+def get_configuration_item(invoking_event):
+    check_defined(invoking_event, 'invokingEvent')
+    if is_oversized_changed_notification(invoking_event['messageType']):
+        configuration_item_summary = check_defined(invoking_event['configurationItemSummary'], 'configurationItemSummary')
+        return get_configuration(configuration_item_summary['resourceType'], configuration_item_summary['resourceId'], configuration_item_summary['configurationItemCaptureTime'])
+    if is_scheduled_notification(invoking_event['messageType']):
+        return None
+    return check_defined(invoking_event['configurationItem'], 'configurationItem')
+
+# Check whether the resource has been deleted. If it has, then the evaluation is unnecessary.
+def is_applicable(configuration_item, event):
+    try:
+        check_defined(configuration_item, 'configurationItem')
+        check_defined(event, 'event')
+    except:
+        return True
+    status = configuration_item['configurationItemStatus']
+    event_left_scope = event['eventLeftScope']
+    if status == 'ResourceDeleted':
+        print("Resource Deleted, setting Compliance Status to NOT_APPLICABLE.")
+
+    return status in ('OK', 'ResourceDiscovered') and not event_left_scope
+
+
+def get_assume_role_credentials(role_arn, region=None):
+    sts_client = boto3.client('sts', region)
+    try:
+        assume_role_response = sts_client.assume_role(RoleArn=role_arn,
+                                                      RoleSessionName="configLambdaExecution",
+                                                      DurationSeconds=CONFIG_ROLE_TIMEOUT_SECONDS)
+        if 'liblogging' in sys.modules:
+            liblogging.logSession(role_arn, assume_role_response)
+        return assume_role_response['Credentials']
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        print(str(ex))
+        if 'AccessDenied' in ex.response['Error']['Code']:
+            ex.response['Error']['Message'] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response['Error']['Message'] = "InternalError"
+            ex.response['Error']['Code'] = "InternalError"
+        raise ex
+
+# This removes older evaluation (usually useful for periodic rule not reporting on AWS::::Account).
+def clean_up_old_evaluations(latest_evaluations, event):
+
+    cleaned_evaluations = []
+
+    old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+        ConfigRuleName=event['configRuleName'],
+        ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+        Limit=100)
+
+    old_eval_list = []
+
+    while True:
+        for old_result in old_eval['EvaluationResults']:
+            old_eval_list.append(old_result)
+        if 'NextToken' in old_eval:
+            next_token = old_eval['NextToken']
+            old_eval = AWS_CONFIG_CLIENT.get_compliance_details_by_config_rule(
+                ConfigRuleName=event['configRuleName'],
+                ComplianceTypes=['COMPLIANT', 'NON_COMPLIANT'],
+                Limit=100,
+                NextToken=next_token)
+        else:
+            break
+
+    for old_eval in old_eval_list:
+        old_resource_id = old_eval['EvaluationResultIdentifier']['EvaluationResultQualifier']['ResourceId']
+        newer_founded = False
+        for latest_eval in latest_evaluations:
+            if old_resource_id == latest_eval['ComplianceResourceId']:
+                newer_founded = True
+        if not newer_founded:
+            cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
+
+    return cleaned_evaluations + latest_evaluations
+
+def lambda_handler(event, context):
+    if 'liblogging' in sys.modules:
+        liblogging.logEvent(event)
+
+    global AWS_CONFIG_CLIENT
+
+    #print(event)
+    check_defined(event, 'event')
+    invoking_event = json.loads(event['invokingEvent'])
+    rule_parameters = {}
+    if 'ruleParameters' in event:
+        rule_parameters = json.loads(event['ruleParameters'])
+
+    try:
+        valid_rule_parameters = evaluate_parameters(rule_parameters)
+    except ValueError as ex:
+        return build_parameters_value_error_response(ex)
+
+    try:
+        AWS_CONFIG_CLIENT = get_client('config', event)
+        if invoking_event['messageType'] in ['ConfigurationItemChangeNotification', 'ScheduledNotification', 'OversizedConfigurationItemChangeNotification']:
+            configuration_item = get_configuration_item(invoking_event)
+            if is_applicable(configuration_item, event):
+                compliance_result = evaluate_compliance(event, configuration_item, valid_rule_parameters)
+            else:
+                compliance_result = "NOT_APPLICABLE"
+        else:
+            return build_internal_error_response('Unexpected message type', str(invoking_event))
+    except botocore.exceptions.ClientError as ex:
+        if is_internal_error(ex):
+            return build_internal_error_response("Unexpected error while completing API request", str(ex))
+        return build_error_response("Customer error while making API request", str(ex), ex.response['Error']['Code'], ex.response['Error']['Message'])
+    except ValueError as ex:
+        return build_internal_error_response(str(ex), str(ex))
+
+    evaluations = []
+    latest_evaluations = []
+
+    if not compliance_result:
+        latest_evaluations.append(build_evaluation(event['accountId'], "NOT_APPLICABLE", event, resource_type='AWS::::Account'))
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, str):
+        if configuration_item:
+            evaluations.append(build_evaluation_from_config_item(configuration_item, compliance_result))
+        else:
+            evaluations.append(build_evaluation(event['accountId'], compliance_result, event, resource_type=DEFAULT_RESOURCE_TYPE))
+    elif isinstance(compliance_result, list):
+        for evaluation in compliance_result:
+            missing_fields = False
+            for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+                if field not in evaluation:
+                    print("Missing " + field + " from custom evaluation.")
+                    missing_fields = True
+
+            if not missing_fields:
+                latest_evaluations.append(evaluation)
+        evaluations = clean_up_old_evaluations(latest_evaluations, event)
+    elif isinstance(compliance_result, dict):
+        missing_fields = False
+        for field in ('ComplianceResourceType', 'ComplianceResourceId', 'ComplianceType', 'OrderingTimestamp'):
+            if field not in compliance_result:
+                print("Missing " + field + " from custom evaluation.")
+                missing_fields = True
+        if not missing_fields:
+            evaluations.append(compliance_result)
+    else:
+        evaluations.append(build_evaluation_from_config_item(configuration_item, 'NOT_APPLICABLE'))
+
+    # Put together the request that reports the evaluation status
+    result_token = event['resultToken']
+    test_mode = False
+    if result_token == 'TESTMODE':
+        # Used solely for RDK test to skip actual put_evaluation API call
+        test_mode = True
+
+    # Invoke the Config API to report the result of the evaluation
+    evaluation_copy = []
+    evaluation_copy = evaluations[:]
+    while evaluation_copy:
+        AWS_CONFIG_CLIENT.put_evaluations(Evaluations=evaluation_copy[:100], ResultToken=result_token, TestMode=test_mode)
+        del evaluation_copy[:100]
+
+    # Used solely for RDK test to be able to test Lambda function
+    return evaluations
+
+def is_internal_error(exception):
+    return ((not isinstance(exception, botocore.exceptions.ClientError)) or exception.response['Error']['Code'].startswith('5')
+            or 'InternalError' in exception.response['Error']['Code'] or 'ServiceError' in exception.response['Error']['Code'])
+
+def build_internal_error_response(internal_error_message, internal_error_details=None):
+    return build_error_response(internal_error_message, internal_error_details, 'InternalError', 'InternalError')
+
+def build_error_response(internal_error_message, internal_error_details=None, customer_error_code=None, customer_error_message=None):
+    error_response = {
+        'internalErrorMessage': internal_error_message,
+        'internalErrorDetails': internal_error_details,
+        'customerErrorMessage': customer_error_message,
+        'customerErrorCode': customer_error_code
+    }
+    print(error_response)
+    return error_response

--- a/rdk/template/runtime/python3.9/rule_test.py
+++ b/rdk/template/runtime/python3.9/rule_test.py
@@ -1,0 +1,160 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+import botocore
+
+##############
+# Parameters #
+##############
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = 'AWS::::Account'
+
+#############
+# Main Code #
+#############
+
+CONFIG_CLIENT_MOCK = MagicMock()
+STS_CLIENT_MOCK = MagicMock()
+
+class Boto3Mock():
+    @staticmethod
+    def client(client_name, *args, **kwargs):
+        if client_name == 'config':
+            return CONFIG_CLIENT_MOCK
+        if client_name == 'sts':
+            return STS_CLIENT_MOCK
+        raise Exception("Attempting to create an unknown client")
+
+sys.modules['boto3'] = Boto3Mock()
+
+RULE = __import__('<%RuleName%>')
+
+class ComplianceTest(unittest.TestCase):
+
+    rule_parameters = '{"SomeParameterKey":"SomeParameterValue","SomeParameterKey2":"SomeParameterValue2"}'
+
+    invoking_event_iam_role_sample = '{"configurationItem":{"relatedEvents":[],"relationships":[],"configuration":{},"tags":{},"configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","awsAccountId":"123456789012","configurationItemStatus":"ResourceDiscovered","resourceType":"AWS::IAM::Role","resourceId":"some-resource-id","resourceName":"some-resource-name","ARN":"some-arn"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+
+    def setUp(self):
+        pass
+
+    def test_sample(self):
+        self.assertTrue(True)
+
+    #def test_sample_2(self):
+    #    RULE.ASSUME_ROLE_MODE = False
+    #    response = RULE.lambda_handler(build_lambda_configurationchange_event(self.invoking_event_iam_role_sample, self.rule_parameters), {})
+    #    resp_expected = []
+    #    resp_expected.append(build_expected_response('NOT_APPLICABLE', 'some-resource-id', 'AWS::IAM::Role'))
+    #    assert_successful_evaluation(self, response, resp_expected)
+
+####################
+# Helper Functions #
+####################
+
+def build_lambda_configurationchange_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_lambda_scheduled_event(rule_parameters=None):
+    invoking_event = '{"messageType":"ScheduledNotification","notificationCreationTime":"2017-12-23T22:11:18.158Z"}'
+    event_to_return = {
+        'configRuleName':'myrule',
+        'executionRoleArn':'roleArn',
+        'eventLeftScope': False,
+        'invokingEvent': invoking_event,
+        'accountId': '123456789012',
+        'configRuleArn': 'arn:aws:config:us-east-1:123456789012:config-rule/config-rule-8fngan',
+        'resultToken':'token'
+    }
+    if rule_parameters:
+        event_to_return['ruleParameters'] = rule_parameters
+    return event_to_return
+
+def build_expected_response(compliance_type, compliance_resource_id, compliance_resource_type=DEFAULT_RESOURCE_TYPE, annotation=None):
+    if not annotation:
+        return {
+            'ComplianceType': compliance_type,
+            'ComplianceResourceId': compliance_resource_id,
+            'ComplianceResourceType': compliance_resource_type
+            }
+    return {
+        'ComplianceType': compliance_type,
+        'ComplianceResourceId': compliance_resource_id,
+        'ComplianceResourceType': compliance_resource_type,
+        'Annotation': annotation
+        }
+
+def assert_successful_evaluation(test_class, response, resp_expected, evaluations_count=1):
+    if isinstance(response, dict):
+        test_class.assertEquals(resp_expected['ComplianceResourceType'], response['ComplianceResourceType'])
+        test_class.assertEquals(resp_expected['ComplianceResourceId'], response['ComplianceResourceId'])
+        test_class.assertEquals(resp_expected['ComplianceType'], response['ComplianceType'])
+        test_class.assertTrue(response['OrderingTimestamp'])
+        if 'Annotation' in resp_expected or 'Annotation' in response:
+            test_class.assertEquals(resp_expected['Annotation'], response['Annotation'])
+    elif isinstance(response, list):
+        test_class.assertEquals(evaluations_count, len(response))
+        for i, response_expected in enumerate(resp_expected):
+            test_class.assertEquals(response_expected['ComplianceResourceType'], response[i]['ComplianceResourceType'])
+            test_class.assertEquals(response_expected['ComplianceResourceId'], response[i]['ComplianceResourceId'])
+            test_class.assertEquals(response_expected['ComplianceType'], response[i]['ComplianceType'])
+            test_class.assertTrue(response[i]['OrderingTimestamp'])
+            if 'Annotation' in response_expected or 'Annotation' in response[i]:
+                test_class.assertEquals(response_expected['Annotation'], response[i]['Annotation'])
+
+def assert_customer_error_response(test_class, response, customer_error_code=None, customer_error_message=None):
+    if customer_error_code:
+        test_class.assertEqual(customer_error_code, response['customerErrorCode'])
+    if customer_error_message:
+        test_class.assertEqual(customer_error_message, response['customerErrorMessage'])
+    test_class.assertTrue(response['customerErrorCode'])
+    test_class.assertTrue(response['customerErrorMessage'])
+    if "internalErrorMessage" in response:
+        test_class.assertTrue(response['internalErrorMessage'])
+    if "internalErrorDetails" in response:
+        test_class.assertTrue(response['internalErrorDetails'])
+
+def sts_mock():
+    assume_role_response = {
+        "Credentials": {
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string"}}
+    STS_CLIENT_MOCK.reset_mock(return_value=True)
+    STS_CLIENT_MOCK.assume_role = MagicMock(return_value=assume_role_response)
+
+##################
+# Common Testing #
+##################
+
+class TestStsErrors(unittest.TestCase):
+
+    def test_sts_unknown_error(self):
+        RULE.ASSUME_ROLE_MODE = True
+        RULE.evaluate_parameters = MagicMock(return_value=True)
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'unknown-code', 'Message': 'unknown-message'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'InternalError', 'InternalError')
+
+    def test_sts_access_denied(self):
+        RULE.ASSUME_ROLE_MODE = True
+        RULE.evaluate_parameters = MagicMock(return_value=True)
+        STS_CLIENT_MOCK.assume_role = MagicMock(side_effect=botocore.exceptions.ClientError(
+            {'Error': {'Code': 'AccessDenied', 'Message': 'access-denied'}}, 'operation'))
+        response = RULE.lambda_handler(build_lambda_configurationchange_event('{}'), {})
+        assert_customer_error_response(
+            self, response, 'AccessDenied', 'AWS Config does not have permission to assume the IAM role.')

--- a/testing/linux-python3-buildspec.yaml
+++ b/testing/linux-python3-buildspec.yaml
@@ -12,14 +12,15 @@ phases:
       - python3 testing/partition_test.py
   build:
     commands:
+      - rdk create LP3_TestRule_P39 --runtime python3.9 --resource-types AWS::EC2::SecurityGroup
       - rdk create LP3_TestRule_P38 --runtime python3.8 --resource-types AWS::EC2::SecurityGroup
       - rdk create LP3_TestRule_P37 --runtime python3.7 --resource-types AWS::EC2::SecurityGroup
       - rdk create LP3_TestRule_P3 --runtime python3.6 --resource-types AWS::EC2::SecurityGroup
       - rdk create LP3_TestRule_JS --runtime nodejs4.3 --resource-types AWS::EC2::SecurityGroup
+      - rdk create LP3_TestRule_EFSFS --runtime python3.9 --resource-types AWS::EFS::FileSystem
       - rdk create LP3_TestRule_CREC --runtime python3.8 --resource-types AWS::Config::ResourceCompliance
       - rdk create LP3_TestRule_ECSTD --runtime python3.7 --resource-types AWS::ECS::TaskDefinition
       - rdk create LP3_TestRule_ECSS --runtime python3.6 --resource-types AWS::ECS::Service
-      - rdk create LP3_TestRule_EFSFS --runtime python2.7 --resource-types AWS::EFS::FileSystem
       - rdk modify LP3_TestRule_P3 --input-parameters '{"TestParameter":"TestValue"}'
       - rdk create LP3_TestRule_P3_Periodic --runtime python3.6 --maximum-frequency One_Hour
       - rdk create LP3_TestRule_P36lib_Periodic --runtime python3.6-lib --maximum-frequency One_Hour
@@ -27,6 +28,8 @@ phases:
       - rdk create LP3_TestRule_P37lib_Periodic --runtime python3.7-lib --maximum-frequency One_Hour
       - rdk create LP3_TestRule_P38_Periodic --runtime python3.8 --maximum-frequency One_Hour
       - rdk create LP3_TestRule_P38lib_Periodic --runtime python3.8-lib --maximum-frequency One_Hour
+      - rdk create LP3_TestRule_P39_Periodic --runtime python3.9 --maximum-frequency One_Hour
+      - rdk create LP3_TestRule_P39lib_Periodic --runtime python3.9-lib --maximum-frequency One_Hour
       - rdk test-local --all
       - rdk deploy --all
       - yes | rdk undeploy LP3_TestRule_P3
@@ -34,6 +37,8 @@ phases:
       - yes | rdk undeploy LP3_TestRule_P37_Periodic
       - yes | rdk undeploy LP3_TestRule_P38
       - yes | rdk undeploy LP3_TestRule_P38_Periodic
+      - yes | rdk undeploy LP3_TestRule_P39
+      - yes | rdk undeploy LP3_TestRule_P39_Periodic
       - sleep 30
       - rdk logs LP3_TestRule_P3
       - yes | rdk undeploy -a

--- a/testing/test_windows.sh
+++ b/testing/test_windows.sh
@@ -18,6 +18,8 @@ if [[ $CODEBUILD_SOURCE_VERSION =~ MyApp\/(.*).zip ]]; then
     version_string="Python37";
   elif [[ ${python_version} == "38" ]]; then
     version_string="Python38";
+  elif [[ ${python_version} == "39" ]]; then
+    version_string="Python39";
   fi
 
   #Construct powershell script to run test and publish results to S3
@@ -28,6 +30,7 @@ if [[ $CODEBUILD_SOURCE_VERSION =~ MyApp\/(.*).zip ]]; then
     set AWS_DEFAULT_REGION=ap-southeast-1
     Set-DefaultAWSRegion -Region ap-southeast-1
     python C:\\${version_string}\Scripts\rdk --region ap-southeast-1 init >C:\tmp\output.txt
+    python C:\\${version_string}\Scripts\rdk --region ap-southeast-1 create WP${python_version}-TestRule-P39 --runtime python3.9 --resource-types AWS::EC2::SecurityGroups >>C:\tmp\output.txt
     python C:\\${version_string}\Scripts\rdk --region ap-southeast-1 create WP${python_version}-TestRule-P38 --runtime python3.8 --resource-types AWS::EC2::SecurityGroups >>C:\tmp\output.txt
     python C:\\${version_string}\Scripts\rdk --region ap-southeast-1 create WP${python_version}-TestRule-P37 --runtime python3.7 --resource-types AWS::EC2::SecurityGroups >>C:\tmp\output.txt
     python C:\\${version_string}\Scripts\rdk --region ap-southeast-1 create WP${python_version}-TestRule-P3 --runtime python3.6 --resource-types AWS::EC2::SecurityGroups >>C:\tmp\output.txt


### PR DESCRIPTION
* No Issue numbers

* Added support for Python 3.9 and Python 3.9 RDKlib runtimes.
* Added AWS::Kinesis and AWS::Backup to accepted resource types list.
* Updated documentation to include Python 3.9 and fixed minor typos.
* Updated Python buildspec file to include Python 3.9 tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
