### PR TITLE
Fix to issue 133 - add OversizedConfigurationItemChangeNotification by default

### DIFF
--- a/rdk/template/configRule.json
+++ b/rdk/template/configRule.json
@@ -178,6 +178,13 @@
             },
             { "Ref": "AWS::NoValue"}]},
             {"Fn::If": [
+            "EventTriggered",
+            {
+              "EventSource": "aws.config",
+              "MessageType": "OversizedConfigurationItemChangeNotification"
+            },
+            { "Ref": "AWS::NoValue"}]},
+            {"Fn::If": [
             "PeriodicTriggered",
             {
               "EventSource": "aws.config",

--- a/rdk/template/configRuleOrganization.json
+++ b/rdk/template/configRuleOrganization.json
@@ -164,10 +164,10 @@
           "InputParameters": { "Ref": "SourceInputParameters" },
           "LambdaFunctionArn": { "Fn::GetAtt": [ "rdkRuleCodeLambda", "Arn" ] },
           "ResourceTypesScope": { "Ref": "SourceEvents" },
-          "OrganizationConfigRuleTriggerTypes": [ {"Fn::If": [
+          "OrganizationConfigRuleTriggerTypes": {"Fn::If": [
             "PeriodicTriggered",
-            "ScheduledNotification" ,
-            "ConfigurationItemChangeNotification" ]} ],
+            [ "ScheduledNotification" ],
+            [ "ConfigurationItemChangeNotification", "OversizedConfigurationItemChangeNotification" ] ]},
           "MaximumExecutionFrequency": {"Fn::If": [
             "PeriodicTriggered",
             { "Ref": "SourcePeriodic" },


### PR DESCRIPTION
*Issue #, if available:*
133
*Description of changes:*
Adding OversizedConfigurationItemChangeNotification as another message type because it's required to be sure that all notifications are handled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
