### PR TITLE
Update rdk.py

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -3658,7 +3658,12 @@ class rdk:
             my_stacks = []
             response = cfn_client.list_stacks()
 
-            for stack in response["StackSummaries"]:
+            all_stacks = response["StackSummaries"]
+            while 'NextToken' in response:
+                response = cfn_client.list_stacks(NextToken=response['NextToken'])
+                all_stacks += response["StackSummaries"]
+
+            for stack in all_stacks:
                 if stack["StackName"] == stackname:
                     my_stacks.append(stack)
 


### PR DESCRIPTION
Proper handling of paginated responses to `cfn_client.list_stacks()` in `__wait_for_cfn_stack()`. Fixes #352

*Issue #, if available:*
Fixes #352

*Description of changes:*
Added pagination handling when listing stacks to fix premature return from `__wait_for_cfn_stack()` function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
