### PR TITLE
Remove unused import and six usage for 2.x support

### DIFF
--- a/rdk/cli.py
+++ b/rdk/cli.py
@@ -8,13 +8,8 @@
 
 import concurrent.futures
 import copy
-import six
-import time
 
-if six.PY2:
-    import rdk
-else:
-    from rdk import rdk
+from rdk import rdk
 
 
 def main():


### PR DESCRIPTION
*Issue #, if available:* #370

*Description of changes:* The purpose of this PR is to remove `six` usage previously intended to support python 2 <> 3 for import handling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
