### PR TITLE
Fix package name to conform to the current module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 #
 #    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 [tool.poetry]
-name = "aws-config-rdk"
+name = "rdk"
 version = "0.10.0"
 description = "Rule Development Kit CLI for AWS Config"
 authors = [


### PR DESCRIPTION
*Description of changes:*  The purpose of this PR is to adjust the package name to conform to the setup.py package name: `rdk`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
