### PR TITLE
Adjust the RTD dependencies for old sphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Configuration file for the Sphinx documentation builder.
 #
 # This file does only contain a selection of the most common options. For a
@@ -23,7 +21,7 @@ sys.path.insert(0, os.path.abspath("../rdk/"))
 # -- Project information -----------------------------------------------------
 
 project = "RDK"
-copyright = "2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved"
+copyright = "2017-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved"
 author = "RDK Maintainers"
 
 # The short X.Y version

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ sphinx-argparse==0.2.5
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-websupport==1.1.0
 PyYAML==5.4.1
-
+jinja2<3.1.0


### PR DESCRIPTION
*Issue #, if available:* #386

*Description of changes:* The goal of this PR is to resolve the RTD build failures (similar to here:  https://readthedocs.org/projects/aws-config-rdk/builds/19116212/)  -- the encountered failure is described here:  https://github.com/readthedocs/readthedocs.org/issues/9037


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
