### PR TITLE
Update RTD url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ custom lambda functions, and provides a streamlined
 develop-deploy-monitor iterative process.
 
 For complete documentation, including command reference, check out the
-[ReadTheDocs documentation](https://rdk.readthedocs.io/en/latest/).
+[ReadTheDocs documentation](https://aws-config-rdk.readthedocs.io/).
 
 ## Getting Started
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The goal of this PR is to ensure we have alignment in the documentation endpoints we are communicating.  rdk.readthedocs will soon be an alias to the new docs, but currently isn't.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
