### PR TITLE
rdk init: only put the configuration recorder if it's not exist

### DIFF
--- a/rdk/rdk.py
+++ b/rdk/rdk.py
@@ -1407,7 +1407,7 @@ class rdk:
                 "arn:" + partition + ":iam::" + account_id + ":role/rdk/config-role"
             )
 
-        if not control_tower:
+        if not control_tower and not config_recorder_exists:
             my_config.put_configuration_recorder(
                 ConfigurationRecorder={
                     "name": config_recorder_name,


### PR DESCRIPTION
*Issue #, if available:*
In the absence of using Control Tower, `rdk init` will try to overwrite the configuration recorder even when there is one. recording All resource types might not be efficient for all environments.
*Description of changes:*
Initialization method of rdk updated to prevent the `put_configuration_recorder` API call when there is a configuration recorder available in AWS Config. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
