### PR TITLE
remove hardcoded rule name from rdklib unit tests

### DIFF
--- a/rdk/template/runtime/python3.10-lib/rule_test.py
+++ b/rdk/template/runtime/python3.10-lib/rule_test.py
@@ -19,8 +19,8 @@ RESOURCE_TYPE = "AWS::IAM::Role"
 # Main Code #
 #############
 
-MODULE = __import__("check_security_hub_aggregator")
-RULE = MODULE.check_security_hub_aggregator()
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
 
 CLIENT_FACTORY = MagicMock()
 

--- a/rdk/template/runtime/python3.11-lib/rule_test.py
+++ b/rdk/template/runtime/python3.11-lib/rule_test.py
@@ -19,8 +19,8 @@ RESOURCE_TYPE = "AWS::IAM::Role"
 # Main Code #
 #############
 
-MODULE = __import__("check_security_hub_aggregator")
-RULE = MODULE.check_security_hub_aggregator()
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
 
 CLIENT_FACTORY = MagicMock()
 

--- a/rdk/template/runtime/python3.7-lib/rule_test.py
+++ b/rdk/template/runtime/python3.7-lib/rule_test.py
@@ -19,8 +19,8 @@ RESOURCE_TYPE = "AWS::IAM::Role"
 # Main Code #
 #############
 
-MODULE = __import__("check_security_hub_aggregator")
-RULE = MODULE.check_security_hub_aggregator()
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
 
 CLIENT_FACTORY = MagicMock()
 

--- a/rdk/template/runtime/python3.8-lib/rule_test.py
+++ b/rdk/template/runtime/python3.8-lib/rule_test.py
@@ -19,8 +19,8 @@ RESOURCE_TYPE = "AWS::IAM::Role"
 # Main Code #
 #############
 
-MODULE = __import__("check_security_hub_aggregator")
-RULE = MODULE.check_security_hub_aggregator()
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
 
 CLIENT_FACTORY = MagicMock()
 

--- a/rdk/template/runtime/python3.9-lib/rule_test.py
+++ b/rdk/template/runtime/python3.9-lib/rule_test.py
@@ -19,8 +19,8 @@ RESOURCE_TYPE = "AWS::IAM::Role"
 # Main Code #
 #############
 
-MODULE = __import__("check_security_hub_aggregator")
-RULE = MODULE.check_security_hub_aggregator()
+MODULE = __import__('<%RuleName%>')
+RULE = MODULE.<%RuleName%>()
 
 CLIENT_FACTORY = MagicMock()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes an accidental change where rdklib unit test templates had a hardcoded value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
