### PR TITLE
passing only the latest evaluations to lambda handler

### DIFF
--- a/rdk/template/runtime/python3.10/rule_code.py
+++ b/rdk/template/runtime/python3.10/rule_code.py
@@ -307,7 +307,7 @@ def clean_up_old_evaluations(latest_evaluations, event):
         if not newer_founded:
             cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
 
-    return cleaned_evaluations + latest_evaluations
+    return latest_evaluations
 
 
 def lambda_handler(event, context):

--- a/rdk/template/runtime/python3.11/rule_code.py
+++ b/rdk/template/runtime/python3.11/rule_code.py
@@ -307,7 +307,7 @@ def clean_up_old_evaluations(latest_evaluations, event):
         if not newer_founded:
             cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
 
-    return cleaned_evaluations + latest_evaluations
+    return latest_evaluations
 
 
 def lambda_handler(event, context):

--- a/rdk/template/runtime/python3.7/rule_code.py
+++ b/rdk/template/runtime/python3.7/rule_code.py
@@ -307,7 +307,7 @@ def clean_up_old_evaluations(latest_evaluations, event):
         if not newer_founded:
             cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
 
-    return cleaned_evaluations + latest_evaluations
+    return latest_evaluations
 
 
 def lambda_handler(event, context):

--- a/rdk/template/runtime/python3.8/rule_code.py
+++ b/rdk/template/runtime/python3.8/rule_code.py
@@ -307,7 +307,7 @@ def clean_up_old_evaluations(latest_evaluations, event):
         if not newer_founded:
             cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
 
-    return cleaned_evaluations + latest_evaluations
+    return latest_evaluations
 
 
 def lambda_handler(event, context):

--- a/rdk/template/runtime/python3.9/rule_code.py
+++ b/rdk/template/runtime/python3.9/rule_code.py
@@ -307,7 +307,7 @@ def clean_up_old_evaluations(latest_evaluations, event):
         if not newer_founded:
             cleaned_evaluations.append(build_evaluation(old_resource_id, "NOT_APPLICABLE", event))
 
-    return cleaned_evaluations + latest_evaluations
+    return latest_evaluations
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
*Issue #, if available:*
The custom config rule when returning a list from evaluate_compliance customer code is not behaving as expected. For example if we consider a config rule on KMS, if there are 10 KMS keys it will only return the last evaluated key under Resources in scope for the config results
*Description of changes:*
clean_up_old_evaluations was passing old resources status as NOT_APPLICABLE, this was causing the issue where only the last resource evaluation was considered. Changed the function to return only the latest evaluations.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
